### PR TITLE
Pass the name of the GPIO to callbacks rather than the GPIO number.

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -184,8 +184,7 @@ static void run_py_callbacks(unsigned int gpio)
          if (cb->bouncetime == 0 || timenow - cb->lastcall > cb->bouncetime*1000 || cb->lastcall == 0 || cb->lastcall > timenow) {
             // run callback
             gstate = PyGILState_Ensure();
-            //result = PyObject_CallFunction(cb->py_cb, "i", chan_from_gpio(gpio));
-            result = PyObject_CallFunction(cb->py_cb, "is", gpio, cb->channel);
+            result = PyObject_CallFunction(cb->py_cb, "s", cb->channel);
 
             if (result == NULL && PyErr_Occurred())
             {


### PR DESCRIPTION
When a callback is invoked as a result of add_event_detect or add_event_callback the parameter is the GPIO number rather than the actual name which is used everywhere else in the python api. I have changed the code so that it now passes in the name, then it is easy to read the GPIO for example. 

def switchHit(channel):
    print("Hit a switch", channel)

GPIO.add_event_detect("P8_46", GPIO.FALLING, switchHit, 50)

When the GPIO falls, the output in this case will be:

('Hit a switch', 'P8_46')

Prior to this patch the output would have been:

('Hit a switch', 71)

Which is totally useless.
