### PR TITLE
Increase the size of the buffer used for storing device tree names.

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -219,9 +219,8 @@ int lookup_uart_by_name(const char *input_name, char *dt)
     uart_t *p;
     for (p = uart_table; p->name != NULL; ++p) {
         if (strcmp(p->name, input_name) == 0) {
-            strncpy(dt, p->dt, 8);
-            dt[8] = '\0';
-            fprintf(stderr, "return 1 lookup_uart_by_name");
+            strncpy(dt, p->dt, FILENAME_BUFFER_SIZE);
+            dt[FILENAME_BUFFER_SIZE - 1] = '\0';
             return 1;                
         }
     }

--- a/source/common.h
+++ b/source/common.h
@@ -34,6 +34,8 @@ SOFTWARE.
 
 #define ARRAY_SIZE(a)  (sizeof(a) / sizeof(a[0]))
 
+#define FILENAME_BUFFER_SIZE 128
+
 int gpio_mode;
 int gpio_direction[120];
 int pwm_pins[120];

--- a/source/py_uart.c
+++ b/source/py_uart.c
@@ -40,7 +40,7 @@ static PyObject *py_cleanup(PyObject *self, PyObject *args)
 // python function setup()
 static PyObject *py_setup_uart(PyObject *self, PyObject *args)
 {
-    char dt[9];
+    char dt[FILENAME_BUFFER_SIZE];
     char *channel;
 
     if (!PyArg_ParseTuple(args, "s", &channel)) {


### PR DESCRIPTION
The previous buffer size was 9 which was not log enough to hold the name of the UART device tree items.  This was causing the UART device trees to fail to load if they weren't already loaded at boot by the OS.  Resolves #34, or at least it does on Ubuntu.
