### PR TITLE
Fixed the use of the "initial" parameter in setup().

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -75,7 +75,7 @@ static PyObject *py_setup_channel(PyObject *self, PyObject *args, PyObject *kwar
    char *channel;
    int direction;
    int pud = PUD_OFF;
-   int initial = -1;
+   int initial = 0;
    static char *kwlist[] = {"channel", "direction", "pull_up_down", "initial", NULL};
 
    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "si|ii", kwlist, &channel, &direction, &pud, &initial))
@@ -108,7 +108,11 @@ static PyObject *py_setup_channel(PyObject *self, PyObject *args, PyObject *kwar
 
    gpio_export(gpio);
    gpio_set_direction(gpio, direction);
-   gpio_set_value(gpio, pud);
+   if (direction == OUTPUT) {
+       gpio_set_value(gpio, initial);
+   } else {
+       gpio_set_value(gpio, pud);
+   }
 
    gpio_direction[gpio] = direction;
 


### PR DESCRIPTION
 This allows the initial state of the port to be set correctly when setting OUTPUT mode.

Tested by calling the function without the optional parameter to verify old behavior (port goes low when the function is called), and by calling with "initial" set to 1, and port stays high when switching from input (with pull up) to output.
