### PR TITLE
Use Travis CI to ensure package can be built with Python 2.7 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+install:
+  - pip install tox 
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands =
+deps =


### PR DESCRIPTION
This will use Tox to just build the package and install it for Python 2.7 and 3.4.

Example setup: https://travis-ci.org/westphahl/adafruit-beaglebone-io-python/