### PR TITLE
- adc fix to work with kernels >=3.14

### DIFF
--- a/source/c_adc.c
+++ b/source/c_adc.c
@@ -30,47 +30,37 @@ SOFTWARE.
 #include "c_adc.h"
 #include "common.h"
 
-char adc_prefix_dir[40];
+const char *adc_prefix_dir = "/sys/bus/iio/devices/iio:device0/";
 
 int adc_initialized = 0;
 
 int initialize_adc(void)
 {
-    char test_path[40];
+    char test_path[60];
     FILE *fh;
     if (adc_initialized) {
         return 1;
     }
 
-    if (load_device_tree("cape-bone-iio")) {
-        build_path("/sys/devices", "ocp.", ocp_dir, sizeof(ocp_dir));
-        build_path(ocp_dir, "helper.", adc_prefix_dir, sizeof(adc_prefix_dir));
-        strncat(adc_prefix_dir, "/AIN", sizeof(adc_prefix_dir));
+    snprintf(test_path, sizeof(test_path), "%s", adc_prefix_dir);
+    fh = fopen(test_path, "r");
 
-        // Test that the directory has an AIN entry (found correct devicetree)
-        snprintf(test_path, sizeof(test_path), "%s%d", adc_prefix_dir, 0);
-        
-        fh = fopen(test_path, "r");
-
-        if (!fh) {
-            return 0; 
-        }
-        fclose(fh);
-
-        adc_initialized = 1;
-        return 1;
+    if (!fh) {
+        return 0;
     }
+    fclose(fh);
 
-    return 0;
+    adc_initialized = 1;
+    return 1;
 }
 
 int read_value(unsigned int ain, float *value)
 {
     FILE * fh;
-    char ain_path[40];
+    char ain_path[60];
     int err, try_count=0;
     int read_successful;
-    snprintf(ain_path, sizeof(ain_path), "%s%d", adc_prefix_dir, ain);
+    snprintf(ain_path, sizeof(ain_path), "%s/in_voltage%d_raw", adc_prefix_dir, ain);
     
     read_successful = 0;
 

--- a/source/py_adc.c
+++ b/source/py_adc.c
@@ -45,8 +45,8 @@ static PyObject *py_setup_adc(PyObject *self, PyObject *args)
         Py_RETURN_NONE;
     
     PyErr_SetString(PyExc_RuntimeError, "Unable to setup ADC system. Possible causes are: \n"
-                                        "  - A cape with a conflicting pin mapping is loaded \n"
-                                        "  - A device tree object is loaded that uses the same name for a fragment: helper");
+                                        "  - Module 'ti_am335x_adc' is not loaded \n"
+                                        "  - ADC channels are not enabled in the overlay \n");
     return NULL;
 }
 
@@ -82,7 +82,7 @@ static PyObject *py_read(PyObject *self, PyObject *args)
     }
 
     //scale modifier
-    value = value / 1800.0;
+    value = value / 4095.0;
 
     py_value = Py_BuildValue("f", value);
 


### PR DESCRIPTION
This fix allows the use of the ADC class with kernels newer than 3.8, that is, with no cape manager. It has been tested with 3.14 kernels. 
The instructions to enable ADC peripherals with 3.14 kernels can be found at
https://github.com/mgaggero/beaglebone/wiki/Make-ADC-working-on-BBB---Ubuntu-kernel-3.14-