### PR TITLE
Add support for on-board LEDs (USR0-USR3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,28 @@ Setup the pin for output, and write GPIO.HIGH or GPIO.LOW. Or you can use 1 or 0
 
     import Adafruit_BBIO.GPIO as GPIO
     GPIO.setup("P8_14", GPIO.OUT) GPIO.output("P8_14", GPIO.HIGH)
+
+**On-Board LEDs**
+
+On-board LEDs (USR0-USR3) are handled by LED class driver rather than the GPIO pin driver.
+
+They have a different path in the /sys/ filesystem.
+
+Setup the pin for output and write GPIO.HIGH or GPIO.LOW.
+
+    import Adafruit_BBIO.GPIO as GPIO
+    import time
+    
+    for i in range(4):
+        GPIO.setup("USR%d" % i, GPIO.OUT)
+
+    while True:
+        for i in range(4):
+            GPIO.output("USR%d" % i, GPIO.HIGH)
+            time.sleep(1)
+        for i in range(4):
+            GPIO.output("USR%d" % i, GPIO.LOW)
+            time.sleep(1)
     
 **GPIO Input**
 

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -170,12 +170,17 @@ int add_fd_list(unsigned int gpio, int fd)
 int open_value_file(unsigned int gpio)
 {
     int fd;
-    char filename[40];
+    char filename[MAX_FILENAME];
 
     // create file descriptor of value file
-    snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
+        snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", gpio -  USR_LED_GPIO_MIN);
+    } else {
+        snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    }
+
     if ((fd = open(filename, O_RDONLY | O_NONBLOCK)) < 0)
-        return -1;
+    return -1;
     add_fd_list(gpio, fd);
     return fd;
 }
@@ -262,10 +267,14 @@ int gpio_get_direction(unsigned int gpio, unsigned int *value)
 int gpio_set_value(unsigned int gpio, unsigned int value)
 {
     int fd;
-    char filename[40];
+    char filename[MAX_FILENAME];
     char vstr[10];
 
-    snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
+        snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", gpio -  USR_LED_GPIO_MIN);
+    } else {
+        snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    }
 
     if ((fd = open(filename, O_WRONLY)) < 0)
         return -1;

--- a/source/event_gpio.h
+++ b/source/event_gpio.h
@@ -40,6 +40,11 @@ SOFTWARE.
 #define HIGH 1
 #define LOW  0
 
+#define MAX_FILENAME 50
+
+#define USR_LED_GPIO_MIN 53
+#define USR_LED_GPIO_MAX 56
+
 #define PUD_OFF  0
 #define PUD_DOWN 1
 #define PUD_UP   2

--- a/test/test_led.py
+++ b/test/test_led.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+
+import Adafruit_BBIO.GPIO as GPIO
+
+def teardown_module(module):
+    GPIO.cleanup()
+
+class TestLED:
+    def test_brightness_high(self):
+        GPIO.setup("USR0", GPIO.OUT)
+        GPIO.output("USR0", GPIO.HIGH)
+        value = open('/sys/class/leds/beaglebone:green:usr0/brightness').read()
+        assert int(value) > 0
+        GPIO.cleanup()
+
+    def test_brightness_low(self):
+        GPIO.setup("USR0", GPIO.OUT)
+        GPIO.output("USR0", GPIO.LOW)
+        value = open('/sys/class/leds/beaglebone:green:usr0/brightness').read()
+        assert int(value) == 0
+        GPIO.cleanup()


### PR DESCRIPTION
Resolves issue #89. The built-in LEDs are handled by the LED class driver and have a different /sys/ path than the GPIO pins.

See PyBBIO library for reference:
https://github.com/graycatlabs/PyBBIO/blob/master/bbio/platform/beaglebone/config.py#L44

Issue reported in this Adafruit forum post:
https://forums.adafruit.com/viewtopic.php?f=49&t=51906