### PR TITLE
Fix format of On-Board LEDs code snippet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ On-board LEDs (USR0-USR3) are handled by LED class driver rather than the GPIO p
 
 They have a different path in the /sys/ filesystem.
 
-Setup the pin for output and write GPIO.HIGH or GPIO.LOW.
+Setup the pin for output and write GPIO.HIGH or GPIO.LOW::
 
     import Adafruit_BBIO.GPIO as GPIO
     import time


### PR DESCRIPTION
@jwcooper  Simple fix so that the On-Board LEDs example code is formatted correctly in the README