### PR TITLE
Update ADC test to handle Linux 4.1+ kernel

### DIFF
--- a/test/test_adc.py
+++ b/test/test_adc.py
@@ -1,7 +1,9 @@
+#debian@beaglebone:~/adafruit-beaglebone-io-python/test$ cat test_adc.py
 import pytest
 import os
-
+import platform
 import Adafruit_BBIO.ADC as ADC
+
 
 def teardown_module(module):
     pass
@@ -17,14 +19,20 @@ class TestAdc:
             ADC.read_raw("P9_40")
 
     def test_setup_adc(self):
+
         ADC.setup()
 
-        files = os.listdir('/sys/devices')
-        ocp = '/sys/devices/'+[s for s in files if s.startswith('ocp')][0]
-        files = os.listdir(ocp)
-        helper_path = ocp+'/'+[s for s in files if s.startswith('helper')][0]
+        kernel = platform.release()
+        if kernel >= '4.1.0':
+            test_path = "/sys/bus/iio/devices/iio:device0/in_voltage1_raw"
+        else:
+            files = os.listdir('/sys/devices')
+            ocp = '/sys/devices/'+[s for s in files if s.startswith('ocp')][0]
+            files = os.listdir(ocp)
+            helper_path = ocp+'/'+[s for s in files if s.startswith('helper')][0]
+            test_path = helper_path + "/AIN1"
 
-        assert os.path.exists(helper_path + "/AIN1")
+        assert os.path.exists(test_path);
         #ADC.cleanup()
 
     def test_read_adc(self):


### PR DESCRIPTION
@jwcooper I've updated the ADC test to handle Linux 4.1+ kernel.

Tested OK with Linux 4.1.15-ti-rt-r43:
```
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ uname -a
Linux beaglebone 4.1.15-ti-rt-r43 #1 SMP PREEMPT RT Thu Jan 21 20:13:58 UTC 2016 armv7l GNU/Linux
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 8.3 (jessie)
Release:	8.3
Codename:	jessie
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ cat /etc/dogtag 
BeagleBoard.org Debian Image 2016-01-24
py ian@beaglebone:~/adafruit-beaglebone-io-python/test$ sudo py.test ./test_adc.p
============================= test session starts ==============================
platform linux2 -- Python 2.7.9, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/debian/adafruit-beaglebone-io-python, inifile: 
collected 6 items 

test_adc.py ......

=========================== 6 passed in 3.50 seconds ===========================
```

Tested OK with Linux 3.8.13-bone79:
```
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ sudo cat /etc/dogtag 
BeagleBoard.org Debian Image 2015-11-12
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ uname -a
Linux beaglebone 3.8.13-bone79 #1 SMP Tue Oct 13 20:44:55 UTC 2015 armv7l GNU/Linux
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 7.10 (wheezy)
Release:	7.10
Codename:	wheezy
debian@beaglebone:~/adafruit-beaglebone-io-python/test$ sudo py.test ./test_adc.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.3, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/debian/adafruit-beaglebone-io-python, inifile: 
collected 6 items 

test_adc.py ......

========================== 6 passed in 12.07 seconds ===========================
```