### PR TITLE
Treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,16 @@ build:
 
 install: build
 	python setup.py install --force
+
+build2:
+	python2 setup.py build --force
+
+install2: build2
+	python2 setup.py install --force
+
+build3:
+	python3 setup.py build --force
+
+install3: build3
+	python3 setup.py install --force
+

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ if kernel >= '4.1.0':
 else:
     kernel41 = None
 
+CFLAGS = ['-Wall', '-Werror', '-Wno-format-security']
+
 classifiers = ['Development Status :: 3 - Alpha',
                'Operating System :: POSIX :: Linux',
                'License :: OSI Approved :: MIT License',
@@ -40,9 +42,9 @@ setup(name             = 'Adafruit_BBIO',
       classifiers      = classifiers,
       packages         = find_packages(),
       py_modules       = ['Adafruit_I2C'],
-      ext_modules      = [Extension('Adafruit_BBIO.GPIO', ['source/py_gpio.c', 'source/event_gpio.c', 'source/c_pinmux.c', 'source/constants.c', 'source/common.c'], extra_compile_args=['-Wno-format-security'], define_macros=kernel41),
-                          Extension('Adafruit_BBIO.PWM', ['source/py_pwm.c', 'source/c_pwm.c', 'source/c_pinmux.c', 'source/constants.c', 'source/common.c'], extra_compile_args=['-Wno-format-security'], define_macros=kernel41),
-                          Extension('Adafruit_BBIO.ADC', ['source/py_adc.c', 'source/c_adc.c', 'source/constants.c', 'source/common.c'], extra_compile_args=['-Wno-format-security'], define_macros=kernel41),
-                          Extension('Adafruit_BBIO.SPI', ['source/spimodule.c', 'source/constants.c', 'source/common.c'], extra_compile_args=['-Wno-format-security'], define_macros=kernel41),
-                          Extension('Adafruit_BBIO.UART', ['source/py_uart.c', 'source/c_uart.c', 'source/constants.c', 'source/common.c'], extra_compile_args=['-Wno-format-security'], define_macros=kernel41)] )
+      ext_modules      = [Extension('Adafruit_BBIO.GPIO', ['source/py_gpio.c', 'source/event_gpio.c', 'source/c_pinmux.c', 'source/constants.c', 'source/common.c'], extra_compile_args=CFLAGS, define_macros=kernel41),
+                          Extension('Adafruit_BBIO.PWM', ['source/py_pwm.c', 'source/c_pwm.c', 'source/c_pinmux.c', 'source/constants.c', 'source/common.c'], extra_compile_args=CFLAGS, define_macros=kernel41),
+                          Extension('Adafruit_BBIO.ADC', ['source/py_adc.c', 'source/c_adc.c', 'source/constants.c', 'source/common.c'], extra_compile_args=CFLAGS, define_macros=kernel41),
+                          Extension('Adafruit_BBIO.SPI', ['source/spimodule.c', 'source/constants.c', 'source/common.c'], extra_compile_args=CFLAGS, define_macros=kernel41),
+                          Extension('Adafruit_BBIO.UART', ['source/py_uart.c', 'source/c_uart.c', 'source/constants.c', 'source/common.c'], extra_compile_args=CFLAGS, define_macros=kernel41)] )
 

--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -564,9 +564,9 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
 BBIO_err pwm_disable(const char *key)
 {
     struct pwm_exp *pwm, *temp, *prev_pwm = NULL;
-    BBIO_err err;
 
 #ifndef BBBVERSION41
+    BBIO_err err;
     char fragment[18];
     snprintf(fragment, sizeof(fragment), "bone_pwm_%s", key);
     err = unload_device_tree(fragment);

--- a/source/common.c
+++ b/source/common.c
@@ -37,6 +37,13 @@ SOFTWARE.
 #include <glob.h>
 #include "common.h"
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0)
+#  ifndef BBBVERSION41
+#    define BBBVERSION41
+#  endif
+#endif
+
 int setup_error = 0;
 int module_setup = 0;
 

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -84,8 +84,11 @@ int gpio_export(unsigned int gpio)
         return -1;
     }
     len = snprintf(str_gpio, sizeof(str_gpio), "%d", gpio);
-    write(fd, str_gpio, len);
+    int ret = write(fd, str_gpio, len);
     close(fd);
+    if (ret < 0) {
+    	return ret;
+    }
 
     // add to list
     new_gpio = malloc(sizeof(struct gpio_exp));
@@ -197,8 +200,11 @@ int gpio_unexport(unsigned int gpio)
         return -1;
 
     len = snprintf(str_gpio, sizeof(str_gpio), "%d", gpio);
-    write(fd, str_gpio, len);
+    int ret = write(fd, str_gpio, len);
     close(fd);
+    if (ret < 0) {
+    	return ret;
+    }
 
     // remove from list
     g = exported_gpios;
@@ -237,8 +243,12 @@ int gpio_set_direction(unsigned int gpio, unsigned int in_flag)
             strncpy(direction, "in", ARRAY_SIZE(direction) - 1);
         }
 
-        write(fd, direction, strlen(direction));
+        int ret = write(fd, direction, strlen(direction));
         close(fd);
+        if (ret < 0) {
+        	return ret;
+        }
+
         return 0;
 }
 
@@ -253,7 +263,10 @@ int gpio_get_direction(unsigned int gpio, unsigned int *value)
         return -1;
 
     lseek(fd, 0, SEEK_SET);
-    read(fd, &direction, sizeof(direction) - 1);
+    int ret = read(fd, &direction, sizeof(direction) - 1);
+    if (ret < 0) {
+    	return ret;
+    }
 
     if (strcmp(direction, "out") == 0) {
         *value = OUTPUT;
@@ -285,8 +298,12 @@ int gpio_set_value(unsigned int gpio, unsigned int value)
         strncpy(vstr, "0", ARRAY_SIZE(vstr) - 1);
     }
 
-    write(fd, vstr, strlen(vstr));
+    int ret = write(fd, vstr, strlen(vstr));
     close(fd);
+    if (ret < 0) {
+    	return ret;
+    }
+
     return 0;
 }
 
@@ -299,10 +316,13 @@ int gpio_get_value(unsigned int gpio, unsigned int *value)
     {
         if ((fd = open_value_file(gpio)) == -1)
             return -1;
-    }    
+    }
 
     lseek(fd, 0, SEEK_SET);
-    read(fd, &ch, sizeof(ch));
+    int ret = read(fd, &ch, sizeof(ch));
+    if (ret < 0) {
+    	return ret;
+    }
 
     if (ch != '0') {
         *value = 1;
@@ -323,8 +343,12 @@ int gpio_set_edge(unsigned int gpio, unsigned int edge)
         if ((fd = open(filename, O_WRONLY)) < 0)
         return -1;
 
-        write(fd, stredge[edge], strlen(stredge[edge]) + 1);
+        int ret = write(fd, stredge[edge], strlen(stredge[edge]) + 1);
         close(fd);
+        if (ret < 0) {
+        	return ret;
+        }
+
         return 0;
 }
 

--- a/source/spimodule.c
+++ b/source/spimodule.c
@@ -36,6 +36,7 @@
 #if PY_MAJOR_VERSION < 3
 #	define PyLong_AS_LONG(val) PyInt_AS_LONG(val)
 #	define PyLong_AsLong(val) PyInt_AsLong(val)
+#	undef  PyLong_Check
 #	define PyLong_Check(val) PyInt_Check(val)
 #endif
 


### PR DESCRIPTION
Added '-Wall', '-Werror' to compiler flags and fixed compilation errors for python2 and python3.