### PR TITLE
Read current duty_ns and pwm_ns before setting default values

### DIFF
--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -522,6 +522,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     // behave properly
     memset(buffer, 0, sizeof(buffer));
     lseek(pwm->duty_fd, 0, SEEK_SET);
+    len = read(pwm->duty_fd, buffer, sizeof(buffer));
     if (len < 0) {
         return BBIO_SYSFS;
     } else if (len >= sizeof(buffer)) {

--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -58,7 +58,7 @@ struct pwm_exp
 };
 struct pwm_exp *exported_pwms = NULL;
 
-struct pwm_exp *lookup_exported_pwm(const char *key) 
+struct pwm_exp *lookup_exported_pwm(const char *key)
 {
     struct pwm_exp *pwm = exported_pwms;
 
@@ -77,7 +77,7 @@ struct pwm_exp *lookup_exported_pwm(const char *key)
 void export_pwm(struct pwm_exp *new_pwm)
 {
     struct pwm_exp *pwm;
-    
+
     if (exported_pwms == NULL)
     {
         // create new list
@@ -128,7 +128,6 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
     }
 
     period_ns = (unsigned long)(1e9 / freq);
-
 
     // If we're going to a shorter period, update the
     // duty cycle first, in order to avoid ever setting
@@ -258,7 +257,7 @@ BBIO_err pwm_set_duty_cycle(const char *key, float duty) {
 
     if (pwm == NULL) {
         return BBIO_GEN;
-    }    
+    }
 
     pwm->duty = duty;
     pwm->duty_ns = (unsigned long)(pwm->period_ns * (duty / 100.0));
@@ -356,7 +355,7 @@ BBIO_err pwm_setup(const char *key, float duty, float freq, int polarity)
         } else {
             perror("stat");
             return BBIO_GEN;
-        } 
+        }
     } else {
         if (S_ISDIR(s.st_mode)) {
             /* It is a directory. Already exported */
@@ -423,7 +422,7 @@ BBIO_err pwm_setup(const char *key, float duty, float freq, int polarity)
     snprintf(period_path, sizeof(period_path), "%s/period", pwm_path);
     snprintf(polarity_path, sizeof(polarity_path), "%s/polarity", pwm_path);
 
-    //add period and duty fd to pwm list    
+    //add period and duty fd to pwm list
     if ((period_fd = open(period_path, O_RDWR)) < 0)
         return BBIO_SYSFS;
 
@@ -570,7 +569,7 @@ BBIO_err pwm_disable(const char *key)
     char buffer[2];
     size_t len;
     pwm = lookup_exported_pwm(key);
-    
+
     // Disable the PWM
     lseek(pwm->enable_fd, 0, SEEK_SET);
     len = snprintf(buffer, sizeof(buffer), "0");


### PR DESCRIPTION
@Dark-Guan reported an issue in [this comment](https://github.com/adafruit/adafruit-beaglebone-io-python/pull/108#issuecomment-242333019) for PR #108 after it was merged:
> I use Linux kamikaze 4.1.6-bone15 Tue Aug 18 12:45:47 UTC 2015 armv7l GNU/Linux
> 
> File "testHardPwm.py", line 6, in 
> PWM.start("P9_14", 50 , 2000, 1)
> RuntimeError: Problem with a sysfs file
> 
> When I run testing demo, the error I get above.
> It's nice that if some body can tell me the problem,thanks!

@MatthewWest worked with @Dark-Guan to [identify the issue and develop a fix](https://github.com/adafruit/adafruit-beaglebone-io-python/pull/108#issuecomment-243331052):
> The invalid argument when setting the duty cycle happens when the duty cycle is set to longer than the period of the pwm. This was happening because we weren't reading the current duty_ns and period_ns from the files. I've written a short patch which reads the current duty_ns and pwm_ns from the files before setting the default values, in order to set the duty and period in the correct order.
> That said, I've written the changes but don't have access to a BeagleBone for the next 2 weeks. So I haven't tested my changes at all, even to see if it will compile. You're welcome to try the code in the develop branch of my repository. I won't submit a pull request until I've had a chance to test it.

I am raising this Pull Request on the behalf of @matthewwest after testing his `develop` branch.