### PR TITLE
ADC.read() returns wrong value

### DIFF
--- a/source/py_adc.c
+++ b/source/py_adc.c
@@ -86,7 +86,7 @@ static PyObject *py_read(PyObject *self, PyObject *args)
     }
 
     //scale modifier
-    value = value / 1800.0;
+    value = value / 4095.0;
 
     py_value = Py_BuildValue("f", value);
 


### PR DESCRIPTION
BBB has 12‐bit ADCs (2^12 = 4,096), meaning a value between 0 and 2^12 − 1 (0 to 4,095), read() should return the raw value divided by 4095, not by 1800.