### PR TITLE
Add PWM support for ecap pins

### DIFF
--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -318,15 +318,13 @@ BBIO_err pwm_setup(const char *key, float duty, float freq, int polarity)
         return BBIO_CAPE;
     }
     // Do pinmuxing
-    fprintf(stderr, "DEBUG: do pinmuxing: key=%s\n", key);
     if(!strcmp(key, "P9_28")) {
-        fprintf(stderr, "DEBUG: P9_28: use pwm2\n");
+        // ecap2 (P9_28) requires mode pwm2
+        // based on bonescript commit 23bf443 by Matthew West
         strncpy(pin_mode, "pwm2", PIN_MODE_LEN);
     } else {
-        fprintf(stderr, "DEBUG: use pwm\n");
         strncpy(pin_mode, "pwm", PIN_MODE_LEN);
     }
-    fprintf(stderr, "DEBUG: set_pin_mode(key=%s, pin_mode=%s)\n", key, pin_mode);
     set_pin_mode(key, pin_mode);
 
     // Get info for pwm

--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -38,6 +38,7 @@ SOFTWARE.
 #endif
 
 #define KEYLEN 7
+#define PIN_MODE_LEN 5
 
 int pwm_initialized = 0;
 
@@ -286,6 +287,7 @@ BBIO_err pwm_setup(const char *key, float duty, float freq, int polarity)
     char period_path[90];
     char polarity_path[90];
     char enable_path[90];
+    char pin_mode[PIN_MODE_LEN]; // "pwm" or "pwm2"
 
     int e;
     int period_fd, duty_fd, polarity_fd, enable_fd;
@@ -316,7 +318,16 @@ BBIO_err pwm_setup(const char *key, float duty, float freq, int polarity)
         return BBIO_CAPE;
     }
     // Do pinmuxing
-    set_pin_mode(key, "pwm");
+    fprintf(stderr, "DEBUG: do pinmuxing: key=%s\n", key);
+    if(!strcmp(key, "P9_28")) {
+        fprintf(stderr, "DEBUG: P9_28: use pwm2\n");
+        strncpy(pin_mode, "pwm2", PIN_MODE_LEN);
+    } else {
+        fprintf(stderr, "DEBUG: use pwm\n");
+        strncpy(pin_mode, "pwm", PIN_MODE_LEN);
+    }
+    fprintf(stderr, "DEBUG: set_pin_mode(key=%s, pin_mode=%s)\n", key, pin_mode);
+    set_pin_mode(key, pin_mode);
 
     // Get info for pwm
     err = get_pwm_by_key(key, &p);

--- a/source/common.c
+++ b/source/common.c
@@ -174,7 +174,8 @@ uart_t uart_table[] = {
 };
 
 // Copied from https://github.com/jadonk/bonescript/blob/master/src/bone.js
-
+// See am335x technical manual, p. 183, for more info:
+// http://www.ti.com/lit/ug/spruh73n/spruh73n.pdf
 pwm_t pwm_table[] = {
   { "ehrpwm2", 6, 1, 4, "ehrpwm.2:1", "EHRPWM2B", "48304000", "48304200", "P8_13"},
   { "ehrpwm2", 5, 0, 4, "ehrpwm.2:0", "EHRPWM2A", "48304000", "48304200", "P8_19"},
@@ -186,10 +187,10 @@ pwm_t pwm_table[] = {
   { "ehrpwm1", 4, 1, 6, "ehrpwm.1:1", "EHRPWM1B", "48302000", "48302200", "P9_16"},
   { "ehrpwm0", 1, 1, 3, "ehrpwm.0:1", "EHRPWM0B", "48300000", "48300200", "P9_21"},
   { "ehrpwm0", 0, 0, 3, "ehrpwm.0:0", "EHRPWM0A", "48300000", "48300200", "P9_22"},
-  { "ecap2", 7, 2, 4, "ecap.2", "ECAPPWM2", "", "", "P9_28"},
+  {   "ecap2", 7, 0, 4, "ecap.2",     "ECAPPWM2", "48304000", "48304100", "P9_28"},
   { "ehrpwm0", 1, 1, 1, "ehrpwm.0:1", "EHRPWM0B", "48300000", "48300200", "P9_29"},
   { "ehrpwm0", 0, 0, 1, "ehrpwm.0:0", "EHRPWM0A", "48300000", "48300200", "P9_31"},
-  { "ecap0", 2, 0, 0, "ecap.0", "ECAPPWM0", "", "", "P9_42"},
+  {   "ecap0", 2, 0, 0, "ecap.0",     "ECAPPWM0", "48300000", "48300100", "P9_42"},
   { NULL, 0, 0, 0, NULL, NULL, NULL, NULL, NULL }
 };
 

--- a/test/test_pwm_setup.py
+++ b/test/test_pwm_setup.py
@@ -48,6 +48,38 @@ class TestPwmSetup:
         assert int(period) == 500000
         PWM.cleanup()
 
+    def test_start_pwm_ecap0(self):
+        print("test_start_pwm_ecap0\n");
+        PWM.cleanup()
+        PWM.start("P9_42", 0)
+        pwm_dir = get_pwm_dir()
+        assert os.path.exists(pwm_dir)
+        if kernel >= '4.1.0':
+            duty = open(pwm_dir + '/duty_cycle').read()
+        else:
+            duty = open(pwm_dir + '/duty').read()
+        period = open(pwm_dir + '/period').read()
+        assert int(duty) == 0
+        assert int(period) == 500000
+        PWM.cleanup()
+
+    # test not enabled as default as
+    # cape-universala overlay required
+    #def test_start_pwm_ecap2(self):
+        #print("test_start_pwm_ecap2\n");
+        #PWM.cleanup()
+        #PWM.start("P9_28", 0)
+        #pwm_dir = get_pwm_dir()
+        #assert os.path.exists(pwm_dir)
+        #if kernel >= '4.1.0':
+            #duty = open(pwm_dir + '/duty_cycle').read()
+        #else:
+            #duty = open(pwm_dir + '/duty').read()
+        #period = open(pwm_dir + '/period').read()
+        #assert int(duty) == 0
+        #assert int(period) == 500000
+        #PWM.cleanup()
+
     def test_start_pwm_with_polarity_one(self):
         PWM.cleanup()
         PWM.start("P9_14", 0, 2000, 1)


### PR DESCRIPTION
Add PWM support for ecap0 (P9_42) and ecap2 (P9_28) as requested in #126 