### PR TITLE
Add support for alternate USR LED labels

### DIFF
--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -182,9 +182,7 @@ int open_value_file(unsigned int gpio)
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
 
-    fprintf(stderr, "open_value_file: open: filename=%s\n", filename);
     if ((fd = open(filename, O_RDONLY | O_NONBLOCK)) < 0) {
-       fprintf(stderr, "open_value_file: open: failed\n");
        return -1;
     }
     add_fd_list(gpio, fd);
@@ -295,16 +293,9 @@ int gpio_set_value(unsigned int gpio, unsigned int value)
         char *usr_led_trigger[] = { "heartbeat", "mmc0", "cpu0", "mmc1" }; 
         int led = gpio -  USR_LED_GPIO_MIN;
 
-        fprintf(stderr, "gpio_set_value: led=%d\n", led);
-
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", led);
 
-        fprintf(stderr, "gpio_set_value: open: filename=%s\n", filename);
-
         if ((fd = open(filename, O_WRONLY)) < 0) {
-           fprintf(stderr, "gpio_set_value: open: failed for led=%d\n", led);
-           fprintf(stderr, "gpio_set_value: trying usr_led_trigger\n");
-           fprintf(stderr, "gpio_set_value: usr_led_trigger[led]=%s\n", usr_led_trigger[led]);
            snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:%s/brightness", usr_led_trigger[led]);
         }
 
@@ -312,9 +303,7 @@ int gpio_set_value(unsigned int gpio, unsigned int value)
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
 
-    fprintf(stderr, "gpio_set_value: open: filename=%s\n", filename);
     if ((fd = open(filename, O_WRONLY)) < 0) {
-       fprintf(stderr, "gpio_set_value: open: failed\n");
         return -1;
     }
 

--- a/source/event_gpio.h
+++ b/source/event_gpio.h
@@ -42,7 +42,7 @@ SOFTWARE.
 #define HIGH 1
 #define LOW  0
 
-#define MAX_FILENAME 50
+#define MAX_FILENAME 60
 
 #define USR_LED_GPIO_MIN 53
 #define USR_LED_GPIO_MAX 56

--- a/test/setup/0001-rename-USR-LED-names-to-test-Adafruit_BBIO-issue-129.patch
+++ b/test/setup/0001-rename-USR-LED-names-to-test-Adafruit_BBIO-issue-129.patch
@@ -1,0 +1,54 @@
+From 88366a61455cbe3e42ab59da939065abeab81597 Mon Sep 17 00:00:00 2001
+From: Drew Fustini <drew@pdp7.com>
+Date: Thu, 5 Jan 2017 02:33:58 -0600
+Subject: [PATCH] rename USR LED names to test Adafruit_BBIO issue #129
+
+Patch for ti-linux-4.4.y branch of ti-linux-kernel-dev which renames
+the labels of the USR LED nodes 
+
+Related issue:
+Doesn't support Ubuntu core beaglebone leds #129
+https://github.com/adafruit/adafruit-beaglebone-io-python/issues/129
+---
+ arch/arm/boot/dts/am335x-bone-common.dtsi | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/am335x-bone-common.dtsi b/arch/arm/boot/dts/am335x-bone-common.dtsi
+index 1f496145..ba95ffc 100644
+--- a/arch/arm/boot/dts/am335x-bone-common.dtsi
++++ b/arch/arm/boot/dts/am335x-bone-common.dtsi
+@@ -26,28 +26,28 @@
+                compatible = "gpio-leds";
+ 
+                led@2 {
+-                       label = "beaglebone:green:usr0";
++                       label = "beaglebone:green:heartbeat";
+                        gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "heartbeat";
+                        default-state = "off";
+                };
+ 
+                led@3 {
+-                       label = "beaglebone:green:usr1";
++                       label = "beaglebone:green:mmc0";
+                        gpios = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "mmc0";
+                        default-state = "off";
+                };
+ 
+                led@4 {
+-                       label = "beaglebone:green:usr2";
++                       label = "beaglebone:green:cpu0";
+                        gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "cpu0";
+                        default-state = "off";
+                };
+ 
+                led@5 {
+-                       label = "beaglebone:green:usr3";
++                       label = "beaglebone:green:mmc1";
+                        gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "mmc1";
+                        default-state = "off";
+-- 
+2.9.3

--- a/test/test_led.py
+++ b/test/test_led.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import errno
 
 import Adafruit_BBIO.GPIO as GPIO
 
@@ -7,16 +8,43 @@ def teardown_module(module):
     GPIO.cleanup()
 
 class TestLED:
-    def test_brightness_high(self):
-        GPIO.setup("USR0", GPIO.OUT)
-        GPIO.output("USR0", GPIO.HIGH)
-        value = open('/sys/class/leds/beaglebone:green:usr0/brightness').read()
-        assert int(value) > 0
+    def set_brightness(self, state, led, name):
+        GPIO.setup(led, GPIO.OUT)
+        GPIO.output(led, state)
+
+        path = "/sys/class/leds/beaglebone:green:{0}/brightness".format(led.lower())
+        value = self.read_led_file(path)
+
+        if value < 0:
+            path = "/sys/class/leds/beaglebone:green:{0}/brightness".format(name)
+            value = self.read_led_file(path)
+
+        if state == 1:
+            assert int(value) > 0
+        else:
+            assert int(value) == 0
         GPIO.cleanup()
 
+    def read_led_file(self, path):
+        try:
+            return open(path).read()
+        except IOError, e:
+            if e.errno == errno.ENOENT:
+                return -1
+
+    def set_all_leds(self, state):
+        test_leds = { "USR0": "heartbeat", \
+                      "USR1": "mmc0", \
+                      "USR2": "cpu0", \
+                      "USR3": "mmc1" }
+        for led, name in test_leds.iteritems():
+            self.set_brightness(state, led, name)
+            GPIO.cleanup()
+   
+    def test_brightness_high(self):
+        self.set_all_leds(GPIO.HIGH)
+
     def test_brightness_low(self):
-        GPIO.setup("USR0", GPIO.OUT)
-        GPIO.output("USR0", GPIO.LOW)
-        value = open('/sys/class/leds/beaglebone:green:usr0/brightness').read()
-        assert int(value) == 0
-        GPIO.cleanup()
+        self.set_all_leds(GPIO.LOW)
+
+

--- a/test/test_led.py
+++ b/test/test_led.py
@@ -11,19 +11,16 @@ class TestLED:
     def set_brightness(self, state, led, name):
         GPIO.setup(led, GPIO.OUT)
         GPIO.output(led, state)
-
-        path = "/sys/class/leds/beaglebone:green:{0}/brightness".format(led.lower())
+        prefix = "/sys/class/leds/beaglebone:green:{0}/brightness"
+        path = prefix.format(led.lower())
         value = self.read_led_file(path)
-
         if value < 0:
-            path = "/sys/class/leds/beaglebone:green:{0}/brightness".format(name)
+            path = prefix.format(name)
             value = self.read_led_file(path)
-
         if state == 1:
             assert int(value) > 0
         else:
             assert int(value) == 0
-        GPIO.cleanup()
 
     def read_led_file(self, path):
         try:


### PR DESCRIPTION
These changes support alternate labels for the USR LEDs based on the triggers name.  This was requested by an Ubuntu Core user in issue #129.

Normal labels:
      * beaglebone:green:usr0
      * beaglebone:green:usr1
      * beaglebone:green:usr2
      * beaglebone:green:usr3
    
Alternate labels:
      * beaglebone:green:heartbeat
      * beaglebone:green:mmc0
      * beaglebone:green:cpu0
      * beaglebone:green:mmc1
    
I've also refactored the pytest script `test_led.py` to cover this new functionality.

However, the device tree bindings on the [official BeagleBoard.org Debian 8.6 ("Jessie") image](https://beagleboard.org/latest-images) must be changed to test the alternate USR LED label functionality.  I've added a patch for `arch/arm/boot/dts/am335x-bone-common.dtsi ` in `ti-linux-4.4.y` branch of the [`ti-linux-kernel-dev` repo](https://github.com/RobertCNelson/ti-linux-kernel-dev/) which renames the labels of the USR LED nodes from usrN to the trigger name.
