### PR TITLE
Make use of io.open() with explicit file encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,13 @@ except:
     pass
 
 import distribute_setup
+import io
 import sys
 import platform
 distribute_setup.use_setuptools()
 from setuptools import setup, Extension, find_packages
+
+open_as_utf8 = lambda x: io.open(x, encoding='utf-8')
 
 kernel = platform.release()
 
@@ -35,7 +38,7 @@ setup(name             = 'Adafruit_BBIO',
       author           = 'Justin Cooper',
       author_email     = 'justin@adafruit.com',
       description      = 'A module to control BeagleBone IO channels',
-      long_description = open('README.rst').read() + open('CHANGELOG.rst').read(),
+      long_description = open_as_utf8('README.rst').read() + open_as_utf8('CHANGELOG.rst').read(),
       license          = 'MIT',
       keywords         = 'Adafruit BeagleBone IO GPIO PWM ADC',
       url              = 'https://github.com/adafruit/adafruit-beaglebone-io-python/',


### PR DESCRIPTION
When installing this module on a system with Python 3 which has no or non-utf8 locale variables set installation fails because you’re making use of the open() command in setup.py to pipe in things like README.rst and CHANGELOG.rst. This happens because Python 3 tries loading those files with the default encoding (which happens to be ASCII), and then fails with an UnicodeDecodeError.

Suggestion: Use io.open(), which is available for both Python 2 and 3 and specify the encoding of said files explicitly.

One could argue that this problem is client-sided, but I don’t see any real drawbacks fixing this on your side.

Thanks.