### PR TITLE
Fix build_path memory leak

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -376,6 +376,7 @@ BBIO_err build_path(const char *partial_path, const char *prefix, char *full_pat
                 int (*errfunc) (const char *epath, int eerrno),
                 glob_t *pglob); */
     int err = glob(pattern, 0, NULL, &results);
+    free(pattern);
     if (err != BBIO_OK) {
         globfree(&results);
         if (err == GLOB_NOSPACE)


### PR DESCRIPTION
Same application as in #138. The small leak in build_path quickly added up and exhausted all my RAM, causing the linux oom-killer to terminate my process. No behavior change, just bugfix, I think.
