### PR TITLE
fix TypeError: function takes exactly 3 arguments (2 given) from wait_for_edge

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -444,10 +444,9 @@ static PyObject *py_wait_for_edge(__attribute__ ((unused)) PyObject *self, PyObj
    char error[30];
    BBIO_err err;
 
-   if (!PyArg_ParseTuple(args, "sii", &channel, &edge, &timeout)){
-      timeout = -1;
-      if (!PyArg_ParseTuple(args, "si", &channel, &edge))
-         return NULL;
+   timeout = -1;
+   if (!PyArg_ParseTuple(args, "si|i", &channel, &edge, &timeout)){
+      return NULL;
    }
 
    err = get_gpio_number(channel, &gpio);


### PR DESCRIPTION
Calling GPIO.wait_for_edge() with only two arguments leads to a latent error that is thrown next time the code hits the C API

My steps to reproduce:

download and install latest image from http://beagleboard.org/latest-images (I used 2017-03-19)

`debian@beaglebone:~$ uname -a`
`Linux beaglebone 4.4.54-ti-r93 #1 SMP Fri Mar 17 13:08:22 UTC 2017 armv7l GNU/Linux`
`debian@beaglebone:~$ cat /etc/dogtag`
`BeagleBoard.org Debian Image 2017-03-19`
`debian@beaglebone:~$ sudo python`
`# snip first time warning #`
`[sudo] password for debian:`
`Python 2.7.9 (default, Aug 13 2016, 17:56:53) `
`[GCC 4.9.2] on linux2`
`Type "help", "copyright", "credits" or "license" for more information.`
`>>> import Adafruit_BBIO.GPIO as GPIO`
`>>> GPIO.setup('P9_15', GPIO.IN)`
`>>> GPIO.wait_for_edge('P9_15',GPIO.FALLING)`
`>>> GPIO.wait_for_edge('P9_15',GPIO.FALLING)`
`TypeError: function takes exactly 3 arguments (2 given)`
`>>> import time`
`>>> GPIO.wait_for_edge('P9_15',GPIO.FALLING)`
`>>> time.sleep(1)`
`TypeError: function takes exactly 3 arguments (2 given)`
`>>>`


Trying to parse 3 required arguments and then falling back to 2 will set the
PyError condition when only two arguments are present even though the
wait_for_edge function as a whole succeeds.  According to
https://docs.python.org/2/c-api/exceptions.html, returning normally after this
will lead to undefined behavior the next time the code enters the C API.

Fix this by using the PyArg_ParseTuple optional argument feature instead of
trying to parse 3 arguments and falling back to 2 if it fails.

Based on a quick grep, it looks to me like this is the only place in the code that has
this problem,  but it wouldn't hurt for someone else to double check this.

Thank you
