### PR TITLE
Check if u-boot overlays are enabled

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -443,6 +443,16 @@ BBIO_err load_device_tree(const char *name)
     FILE *file = NULL;
     char line[256];
     char uboot_overlay;
+    /*
+      Refer to: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
+
+      Robert C. Nelson maintains the BeagleBoard.org Debian images and
+      suggested adding this check to see if u-boot overlays are enabled.
+
+      If u-boot overlays are enabled, then device tree overlays should not
+      be loaded with the cape manager by writing to the slots file.  There
+      is currently a kernel bug that causes the write to hang.
+    */
     const char *cmd = "grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline";
 
 #ifdef BBBVERSION41

--- a/source/common.c
+++ b/source/common.c
@@ -463,24 +463,20 @@ BBIO_err load_device_tree(const char *name)
      build_path("/sys/devices", "bone_capemgr", ctrl_dir, sizeof(ctrl_dir));
 #endif
 
-    fprintf(stderr, "load_device_tree: cmd=%s\n", cmd);
     file = popen(cmd, "r");
     if (file == NULL) {
-        fprintf(stderr, "load_device_tree: failed to grep /proc/cmdline\n");
 #ifndef NO_PYTHON
         PyErr_SetFromErrnoWithFilename(PyExc_IOError, "/proc/cmdline");
 #endif  // !NO_PYTHON
         return BBIO_CAPE;
     }
     uboot_overlay = fgetc(file);
-    fprintf(stderr, "load_device_tree: uboot_overlay=%c\n", uboot_overlay);
     pclose(file);
     if(uboot_overlay == '1') {
       /* Linux kernel booted with u-boot overlays enabled.
          Do not load overlays via slots file as the write
          will hang due to kernel bug in cape manager driver.
          Skip cape manager and just return BBIO_OK. */
-      fprintf(stderr, "load_device_tree: u-boot overlays enable. return BBIO_OK.\n");
       return BBIO_OK;
     }
 

--- a/source/common.c
+++ b/source/common.c
@@ -450,8 +450,27 @@ BBIO_err load_device_tree(const char *name)
 #endif
 
     char line[256];
+    char buf[1035];
+    const char *cmd = "grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline";
+    FILE *fp;
+
+    fprintf(stderr, "load_device_tree: cmd=%s\n", cmd);
+    fp = popen(cmd, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "load_device_tree: failed to run command\n");
+#ifndef NO_PYTHON
+        PyErr_SetFromErrnoWithFilename(PyExc_IOError, cmd);
+#endif  // !NO_PYTHON
+        return BBIO_CAPE;
+    }
+    while (fgets(buf, sizeof(buf)-1, fp) != NULL) {
+      fprintf(stderr, "load_device_tree: %s\n", buf);
+    }
+    pclose(fp);
+
 
     snprintf(slots, sizeof(slots), "%s/slots", ctrl_dir);
+    fprintf(stderr, "load_device_tree: slots=%s\n", slots);
 
     file = fopen(slots, "r+");
     if (!file) {
@@ -462,6 +481,7 @@ BBIO_err load_device_tree(const char *name)
     }
 
     while (fgets(line, sizeof(line), file)) {
+        fprintf(stderr, "load_device_tree: line=%s\n", slots);
         //the device is already loaded, return 1
         if (strstr(line, name)) {
             fclose(file);

--- a/source/common.c
+++ b/source/common.c
@@ -437,46 +437,55 @@ int get_spi_bus_path_number(unsigned int spi)
   }
 }
 
+/*
+   Refer to: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
+
+   Robert C. Nelson maintains the BeagleBoard.org Debian images and
+   suggested adding this check to see if u-boot overlays are enabled.
+
+   If u-boot overlays are enabled, then device tree overlays should not
+   be loaded with the cape manager by writing to the slots file.  There
+   is currently a kernel bug that causes the write to hang.
+*/
+int uboot_overlay_enabled(void) {
+    const char *cmd = "/bin/grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline";
+    char uboot_overlay;
+    FILE *file = NULL;
+
+    file = popen(cmd, "r");
+    if (file == NULL) {
+       fprintf(stderr, "error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
+       return -1;
+    }
+    uboot_overlay = fgetc(file);
+    pclose(file);
+
+    if(uboot_overlay == '1') {
+      return 1;
+    } else {
+      return 0;
+    }
+}
+
 
 BBIO_err load_device_tree(const char *name)
 {
-    FILE *file = NULL;
     char line[256];
-    char uboot_overlay;
-    /*
-      Refer to: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
-
-      Robert C. Nelson maintains the BeagleBoard.org Debian images and
-      suggested adding this check to see if u-boot overlays are enabled.
-
-      If u-boot overlays are enabled, then device tree overlays should not
-      be loaded with the cape manager by writing to the slots file.  There
-      is currently a kernel bug that causes the write to hang.
-    */
-    const char *cmd = "/bin/grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline";
+    FILE *file = NULL;
 
 #ifdef BBBVERSION41
     char slots[41];
     snprintf(ctrl_dir, sizeof(ctrl_dir), "/sys/devices/platform/bone_capemgr");
 #else
-     char slots[40];
-     build_path("/sys/devices", "bone_capemgr", ctrl_dir, sizeof(ctrl_dir));
+    char slots[40];
+    build_path("/sys/devices", "bone_capemgr", ctrl_dir, sizeof(ctrl_dir));
 #endif
 
-    file = popen(cmd, "r");
-    if (file == NULL) {
-#ifndef NO_PYTHON
-        PyErr_SetFromErrnoWithFilename(PyExc_IOError, "/proc/cmdline");
-#endif  // !NO_PYTHON
-        return BBIO_CAPE;
-    }
-    uboot_overlay = fgetc(file);
-    pclose(file);
-    if(uboot_overlay == '1') {
-      /* Linux kernel booted with u-boot overlays enabled.
-         Do not load overlays via slots file as the write
-         will hang due to kernel bug in cape manager driver.
-         Skip cape manager and just return BBIO_OK. */
+    /* Check if the Linux kernel booted with u-boot overlays enabled.
+       If enabled, do not load overlays via slots file as the write
+       will hang due to kernel bug in cape manager driver. Just return
+       BBIO_OK in order to avoid cape manager bug. */
+    if(uboot_overlay_enabled()) {
       return BBIO_OK;
     }
 
@@ -521,6 +530,14 @@ int device_tree_loaded(const char *name)
     build_path("/sys/devices", "bone_capemgr", ctrl_dir, sizeof(ctrl_dir));
 #endif
     char line[256];
+
+    /* Check if the Linux kernel booted with u-boot overlays enabled.
+       If enabled, do not load overlays via slots file as the write
+       will hang due to kernel bug in cape manager driver. Return 1
+       to fake the device tree is loaded to avoid cape manager bug */
+    if(uboot_overlay_enabled()) {
+      return 1;
+    }
 
     snprintf(slots, sizeof(slots), "%s/slots", ctrl_dir);
 


### PR DESCRIPTION
@robertcnelson maintains the BeagleBoard.org Debian images and suggested adding this check to see if u-boot overlays are enabled.

If u-boot overlays are enabled, then device tree overlays should not be loaded with the cape manager by writing to the slots file.  There is currently a kernel bug that causes the write to hang.

Refer to: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays