### PR TITLE
Error handling for setting up pinmux mode in gpio.setup()

### DIFF
--- a/source/c_pinmux.c
+++ b/source/c_pinmux.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <syslog.h>
 
 #include "c_pinmux.h"
 #include "common.h"
@@ -34,10 +35,10 @@ BBIO_err set_pin_mode(const char *key, const char *mode)
 	f = fopen(path, "w");
 	if (NULL == f) {
 		return BBIO_ACCESS;
-	} 
-
+	}
+	syslog(LOG_DEBUG, "set_pin_mode() :: Pinmux file %s access OK", path); 
 	fprintf(f, "%s", mode);
 	fclose(f);
-
+	syslog(LOG_DEBUG, "set_pin_mode() :: Set pinmux mode to %s for %s", mode, pin);
 	return BBIO_OK;
 }

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -138,12 +138,18 @@ static PyObject *py_setup_channel(__attribute__ ((unused)) PyObject *self, PyObj
        }
 
    } else {
-	   if (pud == PUD_DOWN)
-		   set_pin_mode(channel, "gpio_pd");
+       if (pud == PUD_DOWN)
+		   res = set_pin_mode(channel, "gpio_pd");
 	   else if (pud == PUD_UP)
-		   set_pin_mode(channel, "gpio_pu");
+		   res = set_pin_mode(channel, "gpio_pu");
 	   else
-		   set_pin_mode(channel, "gpio");
+		   res = set_pin_mode(channel, "gpio");
+   }
+   
+   //Check if set_pin_mode() returned no error
+   if (res != BBIO_OK) {
+       PyErr_SetString(PyExc_ValueError, "Set gpio mode failed, missing file or invalid permissions.");
+       return NULL;
    }
 
    gpio_direction[gpio] = direction;


### PR DESCRIPTION
I added error handling for the gpio.setup() method in the part where it sets up the pinmux mode. Before it just silently failed if it was unable to write to the corresponding sysfs file.
I also altered underlying set_pin_mode() C function to provide debug output (as it is done in other places) when library is built/run in debug mode
