### PR TITLE
Added BAT25, BAT50, BAT75, BAT100 and WIFI LEDs

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -177,6 +177,11 @@ pins_t table[] = {
     { "GP1_4", "GP1_4",  97, -1, -1},
     { "RED_LED",   "RED",    66, -1, -1},   // LEDs
     { "GREEN_LED", "GREEN",  67, -1, -1},
+    { "BAT25", "BAT25",  27, -1, -1},
+    { "BAT50", "BAT50",  11, -1, -1},
+    { "BAT75", "BAT75",  61, -1, -1},
+    { "BAT100", "BAT100",  10000, -1, -1}, // Placeholder
+    { "WIFI", "WIFI",  10001, -1, -1}, // Placeholder
   
     { "PAUSE", "P8_9",  69, 1, -1},
     { "MODE",  "P8_10", 68, 1, -1},

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -125,7 +125,7 @@ BBIO_err gpio_export(unsigned int gpio)
                gpio, gpio_export, errno, strerror(errno));
         ret =  BBIO_SYSFS;
     }
-    usleep(100000);      // Hack to wait for newly exported pins to get correct ownership
+    usleep(200000);      // Hack to wait for newly exported pins to get correct ownership
     return ret;
 }
 
@@ -195,13 +195,40 @@ int open_value_file(unsigned int gpio)
     // create file descriptor of value file
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", gpio -  USR_LED_GPIO_MIN);
-    } else if(gpio == USR_LED_RED) {     // red LED
-        snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
-    } else if(gpio == USR_LED_GREEN) {     // green LED
-        snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
-    } else {
-        snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    } else switch(gpio) {
+        case USR_LED_RED:
+           snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
+           break;
+        case USR_LED_GREEN:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
+            break;
+        case BAT25:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat25/brightness");
+            break;
+        case BAT50:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat50/brightness");
+            break;
+        case BAT75:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat75/brightness");
+            break;
+        case BAT100:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat100/brightness");
+            break;
+        case WIFI:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/wifi/brightness");
+            break;
+        default:
+            snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+            break;
     }
+    
+    // if(gpio == USR_LED_RED) {     // red LED
+    //     snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
+    // } else if(gpio == USR_LED_GREEN) {     // green LED
+    //     snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
+    // } else {
+    //     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    // }
 
     if ((fd = open(filename, O_RDONLY | O_NONBLOCK)) < 0) {
         syslog(LOG_ERR, "gpio open_value_file: %u couldn't open '%s': %i-%s",
@@ -253,7 +280,10 @@ BBIO_err gpio_set_direction(unsigned int gpio, unsigned int in_flag)
         char direction[10] = { 0 };
 
         if (((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) ||
-                (gpio == USR_LED_RED) || (gpio == USR_LED_GREEN)) {
+                (gpio == USR_LED_RED) || (gpio == USR_LED_GREEN)
+                 || (gpio == BAT25) || (gpio == BAT50)
+                 || (gpio == BAT75) || (gpio == BAT100)
+                 || (gpio == WIFI)) {
             syslog(LOG_DEBUG, "gpio_set_direction: %u not applicable to the USR LED", gpio);
             return BBIO_OK; // direction is not applicable to the USR LED pins
         }
@@ -331,13 +361,40 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
            snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:%s/brightness", usr_led_trigger[led]);
         }
     
-    } else if(gpio == USR_LED_RED) {
-        snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
-    } else if(gpio == USR_LED_GREEN) {
-        snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
-    } else {
-        snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    } else switch(gpio) {
+        case USR_LED_RED:
+           snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
+           break;
+        case USR_LED_GREEN:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
+            break;
+        case BAT25:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat25/brightness");
+            break;
+        case BAT50:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat50/brightness");
+            break;
+        case BAT75:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat75/brightness");
+            break;
+        case BAT100:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/bat100/brightness");
+            break;
+        case WIFI:
+            snprintf(filename, sizeof(filename), "/sys/class/leds/wifi/brightness");
+            break;
+        default:
+            snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+            break;
     }
+
+    // if(gpio == USR_LED_RED) {
+    //     snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
+    // } else if(gpio == USR_LED_GREEN) {
+    //     snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
+    // } else {
+    //     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
+    // }
 
     fd = open(filename, O_WRONLY);
     if (fd < 0) {

--- a/source/event_gpio.h
+++ b/source/event_gpio.h
@@ -50,6 +50,11 @@ SOFTWARE.
 #define USR_LED_GPIO_MAX 56
 #define USR_LED_RED      66
 #define USR_LED_GREEN    67
+#define BAT25   27
+#define BAT50   11
+#define BAT75   61
+#define BAT100  10000       // Placeholder until I find the real number
+#define WIFI    10001       // Ditto
 
 #define PUD_OFF  0
 #define PUD_DOWN 1

--- a/source/examples/python/blinkLEDs.py
+++ b/source/examples/python/blinkLEDs.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import Adafruit_BBIO.GPIO as GPIO
+import time
+
+LEDs = ["USR0", "USR1", "USR2", "USR3", 
+            "GP0_3", "GP0_5", "GP0_6",
+            "GP1_3", "GP1_4",
+            "RED", "GREEN",
+            "BAT25", "BAT50", "BAT75", "BAT100",
+            "WIFI"
+            ]
+delay = 0.25
+
+for LED in LEDs:
+    print(LED)
+    GPIO.setup(LED, GPIO.OUT)
+
+while True:
+    for LED in LEDs:
+        GPIO.output(LED, 1)
+    time.sleep(delay)
+    for LED in LEDs:
+        GPIO.output(LED, 0)
+    time.sleep(delay)

--- a/source/examples/python/button.py
+++ b/source/examples/python/button.py
@@ -6,18 +6,21 @@
 import Adafruit_BBIO.GPIO as GPIO
 import time
 
-button="PAUSE"  # PAUSE=P8_9, MODE=P8_10
-LED   ="RED_LED"
+button= "PAUSE"  # PAUSE=P8_9, MODE=P8_10
+LED1  = "RED"
+LED2  = "WIFI"
 
 # Set the GPIO pins:
-GPIO.setup(LED,    GPIO.OUT)
+GPIO.setup(LED1,  GPIO.OUT)
+GPIO.setup(LED2,  GPIO.OUT)
 GPIO.setup(button, GPIO.IN)
 
 print("Running...")
 
 while True:
   state = GPIO.input(button)
-  GPIO.output(LED, state)
+  GPIO.output(LED1, state)
+  GPIO.output(LED2, state)
   
   GPIO.wait_for_edge(button, GPIO.BOTH)
   print("Pressed")

--- a/source/examples/python/leds.py
+++ b/source/examples/python/leds.py
@@ -3,7 +3,7 @@
 import Adafruit_BBIO.GPIO as GPIO
 import time
 
-LEDs = ["RED_LED", "GREEN_LED"]
+LEDs = ["RED", "GREEN"]
 
 for LED in LEDs:
     GPIO.setup(LED, GPIO.OUT)


### PR DESCRIPTION
Now the battery level and WIFI LEDs can be blinked.  Added blinkLEDs.py to blink all the built in LEDs.

I increased the sleep between exporting a pin and setting the direction to 200ms since 100ms sometimes failed.  It's still a hack, but it works.

--Mark