### PR TITLE
Fix GPIO regression from BeagleBone Blue support

### DIFF
--- a/source/c_pinmux.c
+++ b/source/c_pinmux.c
@@ -36,9 +36,9 @@ BBIO_err set_pin_mode(const char *key, const char *mode)
 	if (NULL == f) {
 		return BBIO_ACCESS;
 	}
-	syslog(LOG_DEBUG, "set_pin_mode() :: Pinmux file %s access OK", path); 
+	syslog(LOG_DEBUG, "Adafruit_BBIO: set_pin_mode() :: Pinmux file %s access OK", path); 
 	fprintf(f, "%s", mode);
 	fclose(f);
-	syslog(LOG_DEBUG, "set_pin_mode() :: Set pinmux mode to %s for %s", mode, pin);
+	syslog(LOG_DEBUG, "Adafruit_BBIO: set_pin_mode() :: Set pinmux mode to %s for %s", mode, pin);
 	return BBIO_OK;
 }

--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -72,7 +72,7 @@ struct pwm_exp *lookup_exported_pwm(const char *key)
         pwm = pwm->next;
     }
 
-    syslog(LOG_DEBUG, "lookup_exported_pwm: couldn't find '%s'", key);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: lookup_exported_pwm: couldn't find '%s'", key);
     return NULL; /* standard for pointers */
 }
 
@@ -109,7 +109,7 @@ BBIO_err initialize_pwm(void)
         }
 #endif
         pwm_initialized = 1;
-        syslog(LOG_INFO, "initialize_pwm: OK");
+        syslog(LOG_INFO, "Adafruit_BBIO: initialize_pwm: OK");
         return BBIO_OK;
     }
 
@@ -124,14 +124,14 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
     struct pwm_exp *pwm;
 
     if (freq <= 0.0) {
-        syslog(LOG_ERR, "pwm_set_frequency: %s freq %f <= 0.0", key, freq);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s freq %f <= 0.0", key, freq);
         return BBIO_INVARG;
     }
 
     pwm = lookup_exported_pwm(key);
 
     if (pwm == NULL) {
-        syslog(LOG_ERR, "pwm_set_frequency: %s couldn't find key", key);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s couldn't find key", key);
         return BBIO_GEN;
     }
 
@@ -148,7 +148,7 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
         len = snprintf(buffer, sizeof(buffer), "%lu", pwm->duty_ns);
         lseek(pwm->duty_fd, 0, SEEK_SET); // Seek to beginning of file
         if (write(pwm->duty_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_frequency: %s couldn't write duty: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s couldn't write duty: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -157,7 +157,7 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
         len = snprintf(buffer, sizeof(buffer), "%lu", period_ns);
         lseek(pwm->period_fd, 0, SEEK_SET); // Seek to beginning of file
         if (write(pwm->period_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_frequency: %s couldn't write period: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s couldn't write period: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -172,7 +172,7 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
         len = snprintf(buffer, sizeof(buffer), "%lu", period_ns);
         lseek(pwm->period_fd, 0, SEEK_SET); // Seek to beginning of file
         if (write(pwm->period_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_frequency: %s couldn't write period: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s couldn't write period: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -182,13 +182,13 @@ BBIO_err pwm_set_frequency(const char *key, float freq) {
         len = snprintf(buffer, sizeof(buffer), "%lu", pwm->duty_ns);
         lseek(pwm->duty_fd, 0, SEEK_SET); // Seek to beginning of file
         if (write(pwm->duty_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_frequency: %s couldn't write duty: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_frequency: %s couldn't write duty: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
     } // else do nothing
 
-    syslog(LOG_DEBUG, "pwm_set_frequency: %s %f OK", key, freq);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_set_frequency: %s %f OK", key, freq);
     return BBIO_OK;
 }
 
@@ -204,7 +204,7 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
     pwm = lookup_exported_pwm(key);
 
     if (pwm == NULL) {
-        syslog(LOG_ERR, "pwm_set_polarity: %s couldn't find key", key);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s couldn't find key", key);
         return BBIO_GEN;
     }
 
@@ -215,7 +215,7 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
     memset(buffer, 0, 9);  // Initialize buffer
     lseek(pwm->enable_fd, 0, SEEK_SET);
     if (read(pwm->enable_fd, buffer, len) < 0) {
-        syslog(LOG_ERR, "pwm_set_polarity: %s couldn't read enable: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s couldn't read enable: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -228,7 +228,7 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
         lseek(pwm->enable_fd, 0, SEEK_SET);
         len = snprintf(buffer, sizeof(buffer), "0");
         if (write(pwm->enable_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_polarity: %s couldn't write enable: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s couldn't write enable: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -242,7 +242,7 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
     } else if (polarity == 1) {
         len = snprintf(buffer, sizeof(buffer), "inversed");
     } else {
-        syslog(LOG_ERR, "pwm_set_polarity: %s invalid argument value: %i", key, polarity);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s invalid argument value: %i", key, polarity);
         return BBIO_INVARG;
     }
 #else
@@ -251,7 +251,7 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
 
     lseek(pwm->polarity_fd, 0, SEEK_SET); // Seek to beginning of file
     if (write(pwm->polarity_fd, buffer, len) < 0) {
-        syslog(LOG_ERR, "pwm_set_polarity: %s couldn't write polarity: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s couldn't write polarity: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -262,14 +262,14 @@ BBIO_err pwm_set_polarity(const char *key, int polarity) {
         lseek(pwm->enable_fd, 0, SEEK_SET);
         len = snprintf(buffer, sizeof(buffer), "1");
         if (write(pwm->enable_fd, buffer, len) < 0) {
-            syslog(LOG_ERR, "pwm_set_polarity: %s couldn't write enable: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_polarity: %s couldn't write enable: %i-%s",
                    key, errno, strerror(errno));
             return BBIO_SYSFS;
         }
     }
 #endif
 
-    syslog(LOG_DEBUG, "pwm_set_polarity: %s %i OK", key, polarity);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_set_polarity: %s %i OK", key, polarity);
     return BBIO_OK;
 }
 
@@ -284,7 +284,7 @@ BBIO_err pwm_set_duty_cycle(const char *key, float duty) {
     pwm = lookup_exported_pwm(key);
 
     if (pwm == NULL) {
-        syslog(LOG_ERR, "pwm_set_duty_cycle: %s couldn't find key", key);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_duty_cycle: %s couldn't find key", key);
         return BBIO_GEN;
     }
 
@@ -294,12 +294,12 @@ BBIO_err pwm_set_duty_cycle(const char *key, float duty) {
     len = snprintf(buffer, sizeof(buffer), "%lu", pwm->duty_ns);
     lseek(pwm->duty_fd, 0, SEEK_SET); // Seek to beginning of file
     if (write(pwm->duty_fd, buffer, len) < 0) {
-        syslog(LOG_ERR, "pwm_set_duty_cycle: %s couldn't write duty: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_set_duty_cycle: %s couldn't write duty: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     }
 
-    syslog(LOG_DEBUG, "pwm_set_duty_cycle: %s %f OK", key, duty);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_set_duty_cycle: %s %f OK", key, duty);
     return BBIO_OK;
 }
 
@@ -330,7 +330,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
     if (!pwm_initialized) {
         err = initialize_pwm();
         if (err != BBIO_OK) {
-            syslog(LOG_ERR, "pwm_setup: %s couldn't initialize pwm: %i", key, err);
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't initialize pwm: %i", key, err);
             return err;
         }
     }
@@ -348,7 +348,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
         || device_tree_loaded("univ-hdmi")       // ""
         || device_tree_loaded("univ-nhdmi")))    // ""
     {
-        syslog(LOG_ERR, "pwm_setup: %s no suitable cape loaded", key);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s no suitable cape loaded", key);
         //FIXME; Assume U-Boot did the work...
         //return BBIO_CAPE;
     }
@@ -365,34 +365,34 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
     // Get info for pwm
     err = get_pwm_by_key(key, &p);
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_setup: %s couldn't get pwm: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't get pwm: %i", key, err);
         return err;
     }
 
     err = build_path(ocp_dir, p->chip, pwm_dev_path, sizeof(pwm_dev_path));
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_setup: %s couldn't build pwm_dev_path: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't build pwm_dev_path: %i", key, err);
         return err;
     }
 
     err = build_path(pwm_dev_path, p->addr, pwm_addr_path, sizeof(pwm_addr_path));
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_setup: %s couldn't build pwm_addr_path: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't build pwm_addr_path: %i", key, err);
         return err;
     }
 
     err = build_path(pwm_addr_path, "pwm/pwmchip", pwm_chip_path, sizeof(pwm_chip_path));
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_setup: %s couldn't build pwm_chip_path: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't build pwm_chip_path: %i", key, err);
         return err;
     }
 
     snprintf(pwm_path, sizeof(pwm_path), "%s/pwm%d", pwm_chip_path, p->index);
-    syslog(LOG_DEBUG, "pwm_start: %s, %s", key, pwm_path);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: %s, %s", key, pwm_path);
 
     //pwm with udev patch
     snprintf(pwm_path_udev, sizeof(pwm_path_udev), "%s/pwm-%c:%d", pwm_chip_path, pwm_path[66], p->index);
-    syslog(LOG_DEBUG, "pwm_start: %s, %s", key, pwm_path_udev);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: %s, %s", key, pwm_path_udev);
 
     // Export PWM if hasn't already been
     e = stat(pwm_path, &s);
@@ -401,14 +401,14 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
             snprintf(pwm_export_path, sizeof(pwm_export_path), "%s/export", pwm_chip_path);
             f = fopen(pwm_export_path, "w");
             if (f == NULL) { // Can't open the export file
-                syslog(LOG_ERR, "pwm_setup: %s couldn't open %s: %i-%s",
+                syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't open %s: %i-%s",
                        key, pwm_export_path, errno, strerror(errno));
                 return BBIO_ACCESS;
             }
             fprintf(f, "%d", p->index);
             fclose(f);
         } else {
-            syslog(LOG_ERR, "pwm_setup: %s couldn't stat %s: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't stat %s: %i-%s",
                    key, pwm_path, errno, strerror(errno));
             perror("stat");
             return BBIO_GEN;
@@ -418,7 +418,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
             /* It is a directory. Already exported */
         } else {
             /* It's a file. Shouldn't ever happen */
-            syslog(LOG_ERR, "pwm_setup: %s %s is not a directory", key, pwm_path);
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s %s is not a directory", key, pwm_path);
             return BBIO_GEN;
         }
     }
@@ -427,14 +427,14 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
     if (-1 == e) {
         if (ENOENT == errno) {
             // Directory still doesn't exist, exit with error
-            syslog(LOG_ERR, "pwm_setup: %s %s doesn't exist", key, pwm_path);
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s %s doesn't exist", key, pwm_path);
             //return BBIO_GEN;
 
             e = stat(pwm_path_udev, &s);
             if (-1 == e) {
                 if (ENOENT == errno) {
                     // Directory still doesn't exist, exit with error
-                    syslog(LOG_ERR, "pwm_setup: %s %s doesn't exist", key, pwm_path_udev);
+                    syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s %s doesn't exist", key, pwm_path_udev);
                     return BBIO_GEN;
                 }
             }
@@ -493,7 +493,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
 
     //add period and duty fd to pwm list
     if ((period_fd = open(period_path, O_RDWR)) < 0) {
-        syslog(LOG_ERR, "pwm_setup: %s couldn't open %s: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't open %s: %i-%s",
                key, period_path, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -501,7 +501,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
     if ((duty_fd = open(duty_path, O_RDWR)) < 0) {
         //error, close already opened period_fd.
         close(period_fd);
-        syslog(LOG_ERR, "pwm_setup: %s couldn't open %s: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't open %s: %i-%s",
                key, duty_path, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -510,7 +510,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
         //error, close already opened period_fd and duty_fd.
         close(period_fd);
         close(duty_fd);
-        syslog(LOG_ERR, "pwm_setup: %s couldn't open %s: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't open %s: %i-%s",
                key, polarity_path, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -521,7 +521,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
         close(period_fd);
         close(duty_fd);
         close(polarity_fd);
-        syslog(LOG_ERR, "pwm_setup: %s couldn't open %s: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't open %s: %i-%s",
                key, enable_path, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -533,7 +533,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
         close(period_fd);
         close(duty_fd);
         close(polarity_fd);
-        syslog(LOG_ERR, "pwm_setup: %s couldn't malloc pwm_exp: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_setup: %s couldn't malloc pwm_exp: %i-%s",
                key, errno, strerror(errno));
         return BBIO_MEM; // out of memory
     }
@@ -552,7 +552,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
 
     export_pwm(new_pwm);
 
-    syslog(LOG_INFO, "pwm_setup: %s OK", key);
+    syslog(LOG_INFO, "Adafruit_BBIO: pwm_setup: %s OK", key);
     return BBIO_OK;
 }
 
@@ -568,7 +568,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     if (pwm == NULL) {
         err = pwm_setup(key, duty, freq, polarity);
         if (err != BBIO_OK) {
-            syslog(LOG_ERR, "pwm_start: %s pwm setup failed: %i", key, err);
+            syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s pwm setup failed: %i", key, err);
             return err;
         }
 
@@ -577,7 +577,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
 
     // If we somehow didn't start successfully
     if (pwm == NULL) {
-        syslog(LOG_ERR, "pwm_start: %s pwm is NULL", key);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s pwm is NULL", key);
         return BBIO_GEN;
     }
 
@@ -594,7 +594,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     lseek(pwm->period_fd, 0, SEEK_SET);
     len = read(pwm->period_fd, buffer, sizeof(buffer));
     if (len < 0) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't read period: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't read period: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     } else if (len >= (ssize_t)sizeof(buffer)) {
@@ -612,7 +612,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     lseek(pwm->duty_fd, 0, SEEK_SET);
     len = read(pwm->duty_fd, buffer, sizeof(buffer));
     if (len < 0) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't read duty: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't read duty: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     } else if (len >= (ssize_t)sizeof(buffer)) {
@@ -628,13 +628,13 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     pwm->duty = duty;
     err = pwm_set_frequency(key, freq);
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't set duty frequency: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't set duty frequency: %i", key, err);
         return err;
     }
 
     err = pwm_set_duty_cycle(key, duty);
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't set duty cycle: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't set duty cycle: %i", key, err);
         return err;
     }
 
@@ -645,13 +645,13 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
     len = snprintf(buffer, sizeof(buffer), "1");
     lseek(pwm->enable_fd, 0, SEEK_SET);
     if (write(pwm->enable_fd, buffer, len) < 0) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't write enable: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't write enable: %i-%s",
                key, errno, strerror(errno));
         return BBIO_SYSFS;
     }
 #endif
 
-    syslog(LOG_INFO, "pwm_start: %s OK", key);
+    syslog(LOG_INFO, "Adafruit_BBIO: pwm_start: %s OK", key);
     return BBIO_OK;
 }
 
@@ -684,7 +684,7 @@ BBIO_err pwm_disable(const char *key)
 	        lseek(pwm->enable_fd, 0, SEEK_SET);
 	        len = snprintf(buffer, sizeof(buffer), "0");
 	        if (write(pwm->enable_fd, buffer, len) < 0) {
-	          syslog(LOG_ERR, "pwm_disable: %s couldn't write enable: %i-%s",
+	          syslog(LOG_ERR, "Adafruit_BBIO: pwm_disable: %s couldn't write enable: %i-%s",
 	                 key, errno, strerror(errno));
 		        return BBIO_SYSFS;
 	        }
@@ -715,7 +715,7 @@ BBIO_err pwm_disable(const char *key)
         }
     }
 
-    syslog(LOG_INFO, "pwm_disable: %s OK", key);
+    syslog(LOG_INFO, "Adafruit_BBIO: pwm_disable: %s OK", key);
     return BBIO_OK;
 }
 

--- a/source/common.c
+++ b/source/common.c
@@ -554,6 +554,7 @@ int uboot_overlay_enabled(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "libadafruit-bbio: error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
        return -1;
     }
     uboot_overlay = fgetc(file);
@@ -577,6 +578,7 @@ int pocketbeagle(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: pocketbeagle() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "libadafruit-bbio: error: pocketbeagle() failed to run cmd=%s\n", cmd);
        return -1;
     }
     pocketbeagle = fgetc(file);
@@ -604,6 +606,7 @@ int beaglebone_blue(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: beaglebone_blue() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "libadafruit-bbio: error: beaglebone_blue() failed to run cmd=%s\n", cmd);
        return -1;
     }
     blue = fgetc(file);

--- a/source/common.c
+++ b/source/common.c
@@ -538,7 +538,6 @@ int get_spi_bus_path_number(unsigned int spi)
 
 /*
    Refer to: http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays
-
    Robert C. Nelson maintains the BeagleBoard.org Debian images and
    suggested adding this check to see if u-boot overlays are enabled.
 
@@ -554,7 +553,7 @@ int uboot_overlay_enabled(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
-       syslog(LOG_ERR, "libadafruit-bbio: error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "Adafruit_BBIO: error: uboot_overlay_enabled() failed to run cmd=%s\n", cmd);
        return -1;
     }
     uboot_overlay = fgetc(file);
@@ -578,7 +577,7 @@ int pocketbeagle(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: pocketbeagle() failed to run cmd=%s\n", cmd);
-       syslog(LOG_ERR, "libadafruit-bbio: error: pocketbeagle() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "Adafruit_BBIO: error: pocketbeagle() failed to run cmd=%s\n", cmd);
        return -1;
     }
     pocketbeagle = fgetc(file);
@@ -606,7 +605,7 @@ int beaglebone_blue(void) {
     file = popen(cmd, "r");
     if (file == NULL) {
        fprintf(stderr, "error: beaglebone_blue() failed to run cmd=%s\n", cmd);
-       syslog(LOG_ERR, "libadafruit-bbio: error: beaglebone_blue() failed to run cmd=%s\n", cmd);
+       syslog(LOG_ERR, "Adafruit_BBIO: error: beaglebone_blue() failed to run cmd=%s\n", cmd);
        return -1;
     }
     blue = fgetc(file);
@@ -776,7 +775,7 @@ void initlog(int level, const char* ident, int option)
     option = BBIO_LOG_OPTION;
   }
   openlog(ident, option, LOG_LOCAL1);
-  syslog(LOG_NOTICE, "libadafruit-bbio version %s initialized", "<unknown>");
+  syslog(LOG_NOTICE, "Adafruit_BBIO: version %s initialized", "<unknown>");
 
   initialized = 1;
 }

--- a/source/common.c
+++ b/source/common.c
@@ -589,6 +589,34 @@ int pocketbeagle(void) {
     }
 }
 
+
+/*
+   Check if board is a BeagleBone Blue
+
+   Refer to GitHub issue for more information:
+   https://github.com/adafruit/adafruit-beaglebone-io-python/issues/178
+*/
+int beaglebone_blue(void) {
+    const char *cmd = "/bin/grep -c 'TI AM335x BeagleBone Blue' /proc/device-tree/model";
+    char blue;
+    FILE *file = NULL;
+
+    file = popen(cmd, "r");
+    if (file == NULL) {
+       fprintf(stderr, "error: beaglebone_blue() failed to run cmd=%s\n", cmd);
+       return -1;
+    }
+    blue = fgetc(file);
+    pclose(file);
+
+    if(blue == '1') {
+      return 1;
+    } else {
+      return 0;
+    }
+}
+
+
 BBIO_err load_device_tree(const char *name)
 {
     char line[256];

--- a/source/common.h
+++ b/source/common.h
@@ -80,6 +80,9 @@ BBIO_err load_device_tree(const char *name);
 BBIO_err unload_device_tree(const char *name);
 int device_tree_loaded(const char *name);
 BBIO_err get_pwm_by_key(const char *key, pwm_t **pwm);
+int uboot_overlay_enabled(void);
+int beaglebone_blue(void);
+int pocketbeagle(void);
 
 #define BBIO_LOG_OPTION LOG_CONS | LOG_PID | LOG_NDELAY
 void initlog(int level, const char* ident, int option);

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -196,7 +196,7 @@ int open_value_file(unsigned int gpio)
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", gpio -  USR_LED_GPIO_MIN);
     } else if (beaglebone_blue()) {
-        fprintf(stderr, "gpio open_value_file: beaglebone_blue() is true\n");
+        syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: beaglebone_blue() is true\n");
         switch(gpio) {
             case USR_LED_RED:
                 snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -224,10 +224,10 @@ int open_value_file(unsigned int gpio)
                 break;
         }
     } else {
-        fprintf(stderr, "gpio open_value_file: default gpio path\n");
+        syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: default gpio path\n");
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
-    fprintf(stderr, "gpio open_value_file: filename=%s\n", filename);
+    syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: filename=%s\n", filename);
     
     // if(gpio == USR_LED_RED) {     // red LED
     //     snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -302,7 +302,6 @@ BBIO_err gpio_set_direction(unsigned int gpio, unsigned int in_flag)
              )
            )
         {
-            fprintf(stderr, "gpio_set_direction: %u not applicable to the USR LED\n", gpio);
             syslog(LOG_DEBUG, "gpio_set_direction: %u not applicable to the USR LED", gpio);
             return BBIO_OK; // direction is not applicable to the USR LED pins
         }
@@ -369,25 +368,6 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
     int fd;
     char filename[MAX_FILENAME];
     char vstr[10];
-
-    if(uboot_overlay_enabled()) {
-      //syslog(LOG_DEBUG, "libadafruit-bbio: uboot_overlay_enabled() is true");
-      fprintf(stderr, "gpio_set_value: uboot_overlay_enabled() is true\n");
-    } else {   
-      fprintf(stderr, "gpio_set_value: uboot_overlay_enabled() is FASLE\n");
-    }
-
-    if(pocketbeagle()) {
-      fprintf(stderr, "gpio_set_value: pocketbeagle() is true\n");
-    } else {   
-      fprintf(stderr, "gpio_set_value: pocketbeagle() is FASLE\n");
-    }
-
-    if(beaglebone_blue()) {
-      fprintf(stderr, "gpio_set_value: beaglebone_blue() is true\n");
-    } else {
-      fprintf(stderr, "gpio_set_value: beaglebone_blue() is FALSE\n");
-    }
 
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
 

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -351,6 +351,31 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
     char filename[MAX_FILENAME];
     char vstr[10];
 
+    if(uboot_overlay_enabled()) {
+      syslog(LOG_DEBUG, "libadafruit-bbio: uboot_overlay_enabled() is true");
+      fprintf(stderr, "libadafruit-bbio: uboot_overlay_enabled() is true\n");
+    } else {   
+      syslog(LOG_DEBUG, "libadafruit-bbio: uboot_overlay_enabled() is FALSE");
+      fprintf(stderr, "libadafruit-bbio: uboot_overlay_enabled() is FASLE\n");
+    }
+
+    if(pocketbeagle()) {
+      syslog(LOG_DEBUG, "libadafruit-bbio: pocketbeagle() is true");
+      fprintf(stderr, "libadafruit-bbio: pocketbeagle() is true\n");
+    } else {   
+      syslog(LOG_DEBUG, "libadafruit-bbio: pocketbeagle() is FALSE");
+      fprintf(stderr, "libadafruit-bbio: pocketbeagle() is FASLE\n");
+    }
+
+    if(beaglebone_blue()) {
+      syslog(LOG_DEBUG, "libadafruit-bbio: beaglebone_blue() is true");
+      fprintf(stderr, "libadafruit-bbio: beaglebone_blue() is true\n");
+    } else {
+      syslog(LOG_DEBUG, "libadafruit-bbio: beaglebone_blue() is FALSE");
+      fprintf(stderr, "libadafruit-bbio: beaglebone_blue() is FALSE\n");
+    }
+
+
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
 
         char *usr_led_trigger[] = { "heartbeat", "mmc0", "cpu0", "mmc1" }; 

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -80,7 +80,7 @@ BBIO_err gpio_export(unsigned int gpio)
 
     // already exported by us?
     if (exported_gpios[gpio] != GPIO_NOT_EXPORTED) {
-        syslog(LOG_DEBUG, "gpio_export: %u already exported", gpio);
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_export: %u already exported", gpio);
         ret = BBIO_OK;
         goto exit;
     }
@@ -91,7 +91,7 @@ BBIO_err gpio_export(unsigned int gpio)
 
     if (access(gpio_path, R_OK|W_OK|X_OK) != -1) {
         exported_gpios[gpio] = GPIO_ALREADY_EXPORTED;
-        syslog(LOG_DEBUG, "gpio_export: %u already exported", gpio);
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_export: %u already exported", gpio);
         ret =  BBIO_OK;
         goto exit;
     }
@@ -99,7 +99,7 @@ BBIO_err gpio_export(unsigned int gpio)
     const char gpio_export[] = "/sys/class/gpio/export";
 
     if ((fd = open(gpio_export, O_WRONLY)) < 0) {
-        syslog(LOG_ERR, "gpio_export: %u couldn't open \"%s\": %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_export: %u couldn't open \"%s\": %i-%s",
                gpio, gpio_export, errno, strerror(errno));
         ret =  BBIO_SYSFS;
         goto exit;
@@ -107,7 +107,7 @@ BBIO_err gpio_export(unsigned int gpio)
 
     len = snprintf(str_gpio, sizeof(str_gpio), "%d", gpio);
     if(write(fd, str_gpio, len) < 0) {
-        syslog(LOG_ERR, "gpio_export: %u couldn't write \"%s\": %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_export: %u couldn't write \"%s\": %i-%s",
                gpio, gpio_export, errno, strerror(errno));
         ret =  BBIO_SYSFS;
         goto exit;
@@ -116,12 +116,12 @@ BBIO_err gpio_export(unsigned int gpio)
     // add to list
     exported_gpios[gpio] = GPIO_EXPORTED;
 
-    syslog(LOG_DEBUG, "gpio_export: %u OK", gpio);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_export: %u OK", gpio);
     ret = BBIO_OK;
 
     exit:
     if(fd && (ret = close(fd))) {
-        syslog(LOG_ERR, "gpio_export: %u couldn't close \"%s\": %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_export: %u couldn't close \"%s\": %i-%s",
                gpio, gpio_export, errno, strerror(errno));
         ret =  BBIO_SYSFS;
     }
@@ -196,7 +196,7 @@ int open_value_file(unsigned int gpio)
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", gpio -  USR_LED_GPIO_MIN);
     } else if (beaglebone_blue()) {
-        syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: beaglebone_blue() is true\n");
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio open_value_file: beaglebone_blue() is true\n");
         switch(gpio) {
             case USR_LED_RED:
                 snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -224,10 +224,10 @@ int open_value_file(unsigned int gpio)
                 break;
         }
     } else {
-        syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: default gpio path\n");
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio open_value_file: default gpio path\n");
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
-    syslog(LOG_DEBUG, "libadafruit-bbio: gpio open_value_file: filename=%s\n", filename);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio open_value_file: filename=%s\n", filename);
     
     // if(gpio == USR_LED_RED) {     // red LED
     //     snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -268,7 +268,7 @@ BBIO_err gpio_unexport(unsigned int gpio)
     int ret = write(fd, str_gpio, len);
     close(fd);
     if (ret < 0) {
-      syslog(LOG_ERR, "gpio_unexport: %u couldn't write '"GPIO_UNEXPORT"': %i-%s",
+      syslog(LOG_ERR, "Adafruit_BBIO: gpio_unexport: %u couldn't write '"GPIO_UNEXPORT"': %i-%s",
              gpio, errno, strerror(errno));
       return BBIO_SYSFS;
     }
@@ -276,7 +276,7 @@ BBIO_err gpio_unexport(unsigned int gpio)
     // remove from list
     exported_gpios[gpio] = GPIO_NOT_EXPORTED;
 
-    syslog(LOG_DEBUG, "gpio_unexport: %u OK", gpio);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_unexport: %u OK", gpio);
     return BBIO_OK;
 }
 
@@ -302,13 +302,13 @@ BBIO_err gpio_set_direction(unsigned int gpio, unsigned int in_flag)
              )
            )
         {
-            syslog(LOG_WARNING, "gpio_set_direction: %u not applicable to built-in LEDs", gpio);
+            syslog(LOG_WARNING, "Adafruit_BBIO: gpio_set_direction: %u not applicable to built-in LEDs", gpio);
             return BBIO_OK; // direction is not applicable to the USR LED pins
         }
 
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/direction", gpio);
         if ((fd = open(filename, O_WRONLY)) < 0) {
-            syslog(LOG_ERR, "gpio_set_direction: %u couldn't open '%s': %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_direction: %u couldn't open '%s': %i-%s",
                    gpio, filename, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -322,12 +322,12 @@ BBIO_err gpio_set_direction(unsigned int gpio, unsigned int in_flag)
         int ret = write(fd, direction, strlen(direction));
         close(fd);
         if (ret < 0) {
-            syslog(LOG_ERR, "gpio_set_direction: %u couldn't write '%s': %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_direction: %u couldn't write '%s': %i-%s",
                    gpio, filename, errno, strerror(errno));
             return BBIO_SYSFS;
         }
 
-        syslog(LOG_DEBUG, "gpio_set_direction: %u OK", gpio);
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_direction: %u OK", gpio);
         return BBIO_OK;
 }
 
@@ -339,7 +339,7 @@ BBIO_err gpio_get_direction(unsigned int gpio, unsigned int *value)
 
     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/direction", gpio);
     if ((fd = open(filename, O_RDONLY | O_NONBLOCK)) < 0) {
-        syslog(LOG_ERR, "gpio_get_direction: %u couldn't open '%s': %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_get_direction: %u couldn't open '%s': %i-%s",
                gpio, filename, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -348,7 +348,7 @@ BBIO_err gpio_get_direction(unsigned int gpio, unsigned int *value)
     int ret = read(fd, &direction, sizeof(direction) - 1);
     close(fd);
     if (ret < 0) {
-        syslog(LOG_ERR, "gpio_get_direction: %u couldn't read '%s': %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_get_direction: %u couldn't read '%s': %i-%s",
                gpio, filename, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -359,7 +359,7 @@ BBIO_err gpio_get_direction(unsigned int gpio, unsigned int *value)
         *value = INPUT;
     }
 
-    syslog(LOG_DEBUG, "gpio_get_direction: %u OK", gpio);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_get_direction: %u OK", gpio);
     return BBIO_OK;
 }
 
@@ -396,14 +396,14 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
         char *usr_led_trigger[] = { "heartbeat", "mmc0", "cpu0", "mmc1" }; 
         int led = gpio -  USR_LED_GPIO_MIN;
 
-        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: USR LED path\n");
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_value: USR LED path\n");
 
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", led);
         if (access(filename, W_OK) < 0) {
            snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:%s/brightness", usr_led_trigger[led]);
         }
     } else if (beaglebone_blue()) {
-        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: beaglebone_blue() is true\n");
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_value: beaglebone_blue() is true\n");
         switch(gpio) {
             case USR_LED_RED:
                snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -431,14 +431,14 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
                 break;
         }
     } else {
-        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: default gpio path\n");
+        syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_value: default gpio path\n");
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
-    syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: filename=%s\n", filename);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_value: filename=%s\n", filename);
 
     fd = open(filename, O_WRONLY);
     if (fd < 0) {
-        syslog(LOG_ERR, "gpio_set_value: %u couldn't open '%s': %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_value: %u couldn't open '%s': %i-%s",
                gpio, filename, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -452,12 +452,12 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
     int ret = write(fd, vstr, strlen(vstr));
     close(fd);
     if (ret < 0) {
-        syslog(LOG_ERR, "gpio_set_value: %u couldn't write '%s': %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_value: %u couldn't write '%s': %i-%s",
                gpio, filename, errno, strerror(errno));
         return BBIO_SYSFS;
     }
 
-    syslog(LOG_DEBUG, "gpio_set_value: %u %u OK", gpio, value);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_set_value: %u %u OK", gpio, value);
     return BBIO_OK;
 }
 
@@ -469,7 +469,7 @@ BBIO_err gpio_get_value(unsigned int gpio, unsigned int *value)
     if (!fd)
     {
         if ((fd = open_value_file(gpio)) == -1) {
-            syslog(LOG_ERR, "gpio_set_value: %u couldn't open value file: %i-%s",
+            syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_value: %u couldn't open value file: %i-%s",
                    gpio, errno, strerror(errno));
             return BBIO_SYSFS;
         }
@@ -478,7 +478,7 @@ BBIO_err gpio_get_value(unsigned int gpio, unsigned int *value)
     lseek(fd, 0, SEEK_SET);
     int ret = read(fd, &ch, sizeof(ch));
     if (ret < 0) {
-        syslog(LOG_ERR, "gpio_set_value: %u couldn't read value file: %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio_set_value: %u couldn't read value file: %i-%s",
                gpio, errno, strerror(errno));
         return BBIO_SYSFS;
     }
@@ -489,7 +489,7 @@ BBIO_err gpio_get_value(unsigned int gpio, unsigned int *value)
         *value = 0;
     }
 
-    syslog(LOG_DEBUG, "gpio_get_value: %u OK", gpio);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: gpio_get_value: %u OK", gpio);
     return BBIO_OK;
 }
 

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -369,17 +369,41 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
     char filename[MAX_FILENAME];
     char vstr[10];
 
+    // TODO: remove this debug output created for issue #178
+    /*
+    if(uboot_overlay_enabled()) {
+      fprintf(stderr, "gpio_set_value: uboot_overlay_enabled() is true\n");
+    } else {
+      fprintf(stderr, "gpio_set_value: uboot_overlay_enabled() is FASLE\n");
+    }
+
+    if(pocketbeagle()) {
+      fprintf(stderr, "gpio_set_value: pocketbeagle() is true\n");
+    } else {
+      fprintf(stderr, "gpio_set_value: pocketbeagle() is FASLE\n");
+    }
+
+    if(beaglebone_blue()) {
+      fprintf(stderr, "gpio_set_value: beaglebone_blue() is true\n");
+    } else {
+      fprintf(stderr, "gpio_set_value: beaglebone_blue() is FALSE\n");
+    }
+    */
+
+
     if ((gpio >= USR_LED_GPIO_MIN) && (gpio <=  USR_LED_GPIO_MAX)) {
 
         char *usr_led_trigger[] = { "heartbeat", "mmc0", "cpu0", "mmc1" }; 
         int led = gpio -  USR_LED_GPIO_MIN;
+
+        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: USR LED path\n");
 
         snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:usr%d/brightness", led);
         if (access(filename, W_OK) < 0) {
            snprintf(filename, sizeof(filename), "/sys/class/leds/beaglebone:green:%s/brightness", usr_led_trigger[led]);
         }
     } else if (beaglebone_blue()) {
-        fprintf(stderr, "gpio_set_value: beaglebone_blue() is true\n");
+        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: beaglebone_blue() is true\n");
         switch(gpio) {
             case USR_LED_RED:
                snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
@@ -407,18 +431,10 @@ BBIO_err gpio_set_value(unsigned int gpio, unsigned int value)
                 break;
         }
     } else {
-        fprintf(stderr, "gpio_set_value: default gpio path\n");
+        syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: default gpio path\n");
         snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
     }
-    fprintf(stderr, "gpio_set_value: filename=%s\n", filename);
-
-    // if(gpio == USR_LED_RED) {
-    //     snprintf(filename, sizeof(filename), "/sys/class/leds/red/brightness");
-    // } else if(gpio == USR_LED_GREEN) {
-    //     snprintf(filename, sizeof(filename), "/sys/class/leds/green/brightness");
-    // } else {
-    //     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/value", gpio);
-    // }
+    syslog(LOG_DEBUG, "libadafruit-bbio: gpio_set_value: filename=%s\n", filename);
 
     fd = open(filename, O_WRONLY);
     if (fd < 0) {

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -302,7 +302,7 @@ BBIO_err gpio_set_direction(unsigned int gpio, unsigned int in_flag)
              )
            )
         {
-            syslog(LOG_DEBUG, "gpio_set_direction: %u not applicable to the USR LED", gpio);
+            syslog(LOG_WARNING, "gpio_set_direction: %u not applicable to built-in LEDs", gpio);
             return BBIO_OK; // direction is not applicable to the USR LED pins
         }
 

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -582,7 +582,7 @@ PyMODINIT_FUNC initGPIO(void)
 
    define_constants(module);
 
-   initlog(LOG_NOTICE, NULL, BBIO_LOG_OPTION);
+   initlog(LOG_DEBUG, NULL, BBIO_LOG_OPTION);
 
    if (!PyEval_ThreadsInitialized())
       PyEval_InitThreads();

--- a/source/py_pwm.c
+++ b/source/py_pwm.c
@@ -252,7 +252,7 @@ PyMODINIT_FUNC initPWM(void)
 
    define_constants(module);
 
-   initlog(LOG_NOTICE, NULL, BBIO_LOG_OPTION);
+   initlog(LOG_DEBUG, NULL, BBIO_LOG_OPTION);
 
 #if PY_MAJOR_VERSION > 2
     return module;

--- a/test/issue178.py
+++ b/test/issue178.py
@@ -1,0 +1,49 @@
+# These are all the LEDs defined in source/event_gpio.h:
+#   #define USR_LED_GPIO_MIN 53
+#   #define USR_LED_GPIO_MAX 56
+#   #define USR_LED_RED      66
+#   #define USR_LED_GREEN    67
+#   #define BAT25   27
+#   #define BAT50   11
+#   #define BAT75   61
+#   #define BAT100  10000       // Placeholder until I find the real number
+#   #define WIFI    10001       // Ditto
+#
+# which map to entries in pins_t table[] in source/common.c
+#
+#   66
+#       BeagleBone (not Blue): { "TIMER4", "P8_7", 66, -1, -1},
+#       BeagleBone Blue: { "RED_LED", "RED", 66, -1, -1}, // LEDs
+#
+#   67
+#       BeagleBone (not Blue): { "TIMER7", "P8_8", 67, -1, -1},
+#       BeagleBone Blue: { "GREEN_LED", "GREEN", 67, -1, -1},
+#
+#   27
+#       BeagleBone (not Blue): { "GPIO0_27", "P8_17", 27, -1, -1},
+#       BeagleBone Blue: { "BAT25", "BAT25", 27, -1, -1},
+#       PocketBeagle: { "GPIO0_27", "P2_19", 27, -1, -1},
+#
+#   11
+#       BeagleBone (not Blue): { "UART5_RTSN", "P8_32", 11, -1, -1},
+#       BeagleBone Blue: { "BAT50", "BAT50", 11, -1, -1},
+#
+#   61
+#       BeagleBone (not Blue): { "GPIO1_29", "P8_26", 61, -1, -1},
+#       BeagleBone Blue: { "BAT75", "BAT75", 61, -1, -1},
+#
+
+import Adafruit_BBIO.GPIO as GPIO
+
+test_pins = [ "P8_7", "P8_8", "P8_17", "P8_32", "P8_26" ]
+
+for pin in test_pins:
+  print("========================")
+  print("test GPIO.setup(): {0}".format(pin))
+  GPIO.setup(pin, GPIO.OUT)
+  print("test GPIO.output(): {0}".format(pin))
+  GPIO.output(pin, GPIO.HIGH)
+  value = GPIO.input(pin);
+  print("test GPIO.input(): {0}={1}".format(pin, value));
+
+GPIO.cleanup()

--- a/test/issue178.py
+++ b/test/issue178.py
@@ -35,7 +35,11 @@
 
 import Adafruit_BBIO.GPIO as GPIO
 
-test_pins = [ "P8_7", "P8_8", "P8_17", "P8_32", "P8_26" ]
+test_pins = [
+              "USR0", "USR1", "USR2", "USR3",
+              "RED_LED", "GREEN_LED", "BAT25", "BAT50", "BAT75",
+              "P8_7", "P8_8", "P8_17", "P8_32", "P8_26"
+            ]
 
 for pin in test_pins:
   print("========================")


### PR DESCRIPTION
Fix GPIO regression caused by the support for the additional BeagleBone Blue built-in LEDs.  Refer to issue #178.

### Version information for tests
```
debian@beaglebone:~/ssh/adafruit-beaglebone-io-python/test$ sudo /opt/scripts/tools/version.sh
git:/opt/scripts/:[6c2688b0be448b7bb9ca18849b430d496a84acb4]
eeprom:[A335BNLT000C3014BBBK1316]
model:[TI_AM335x_BeagleBone_Black]
dogtag:[BeagleBoard.org Debian Image 2017-10-17]
bootloader:[microSD-(push-button)]:[/dev/mmcblk0]:[U-Boot 2017.09-00002-g0f3f1c7907]
bootloader:[eMMC-(default)]:[/dev/mmcblk1]:[U-Boot 2017.09-rc2-00002-g84a7f2]
kernel:[4.9.57-ti-r71]
nodejs:[v6.11.4]
uboot_overlay_options:[enable_uboot_overlays=1]
uboot_overlay_options:[uboot_overlay_pru=/lib/firmware/AM335X-PRU-RPROC-4-4-TI-00A0.dtbo]
uboot_overlay_options:[enable_uboot_cape_universal=1]
pkg:[bb-cape-overlays]:[4.4.20171013.2-0rcnee1~stretch+20171013]
pkg:[bb-wl18xx-firmware]:[1.20170829-0rcnee1~stretch+20170829]
pkg:[firmware-ti-connectivity]:[20170823-1rcnee0~stretch+20170830]
```
### Results for pytest
```
debian@beaglebone:~/ssh/adafruit-beaglebone-io-python/test$ sudo python -m pytest
=================================================== test session starts ====================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/debian/ssh/adafruit-beaglebone-io-python, inifile:
collected 58 items

test_adc.py ......
test_gpio_input.py ..
test_gpio_output.py ......
test_gpio_setup.py ..........
test_led.py ..
test_pwm_setup.py ...........................
test_spi.py ..
test_uart.py ...

================================================ 58 passed in 13.31 seconds ================================================
```
### Results for Issue #178 test
```
debian@beaglebone:~/ssh/adafruit-beaglebone-io-python$ sudo python ./test/issue178.py
========================
test GPIO.setup(): USR0
test GPIO.output(): USR0
test GPIO.input(): USR0=1
========================
test GPIO.setup(): USR1
test GPIO.output(): USR1
test GPIO.input(): USR1=1
========================
test GPIO.setup(): USR2
test GPIO.output(): USR2
test GPIO.input(): USR2=1
========================
test GPIO.setup(): USR3
test GPIO.output(): USR3
test GPIO.input(): USR3=1
========================
test GPIO.setup(): RED_LED
test GPIO.output(): RED_LED
test GPIO.input(): RED_LED=1
========================
test GPIO.setup(): GREEN_LED
test GPIO.output(): GREEN_LED
test GPIO.input(): GREEN_LED=1
========================
test GPIO.setup(): BAT25
test GPIO.output(): BAT25
test GPIO.input(): BAT25=1
========================
test GPIO.setup(): BAT50
test GPIO.output(): BAT50
test GPIO.input(): BAT50=1
========================
test GPIO.setup(): BAT75
test GPIO.output(): BAT75
test GPIO.input(): BAT75=1
========================
test GPIO.setup(): P8_7
test GPIO.output(): P8_7
test GPIO.input(): P8_7=1
========================
test GPIO.setup(): P8_8
test GPIO.output(): P8_8
test GPIO.input(): P8_8=1
========================
test GPIO.setup(): P8_17
test GPIO.output(): P8_17
test GPIO.input(): P8_17=1
========================
test GPIO.setup(): P8_32
test GPIO.output(): P8_32
test GPIO.input(): P8_32=1
========================
test GPIO.setup(): P8_26
test GPIO.output(): P8_26
test GPIO.input(): P8_26=1
```

### Debug logging
```
journalctl -p debug -t python --since "1 min ago"

-- Logs begin at Tue 2017-10-24 20:55:42 UTC, end at Tue 2017-10-31 04:02:47 UTC. --
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: version <unknown> initialized
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 53 couldn't write "/sys/class/gpio/export": 16-Device or resource busy
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 53 not applicable to built-in LEDs
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr0/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 53 0 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr0/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 53 1 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/leds/beaglebone:green:usr0/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 53 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 54 couldn't write "/sys/class/gpio/export": 16-Device or resource busy
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 54 not applicable to built-in LEDs
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr1/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 54 0 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr1/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 54 1 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/leds/beaglebone:green:usr1/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 54 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 55 couldn't write "/sys/class/gpio/export": 16-Device or resource busy
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 55 not applicable to built-in LEDs
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr2/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 55 0 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr2/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 55 1 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/leds/beaglebone:green:usr2/brightness
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 55 OK
Oct 31 04:02:43 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 56 couldn't write "/sys/class/gpio/export": 16-Device or resource busy
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 56 not applicable to built-in LEDs
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr3/brightness
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 56 0 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: USR LED path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/leds/beaglebone:green:usr3/brightness
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 56 1 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/leds/beaglebone:green:usr3/brightness
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 56 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 66 already exported
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 66 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio66/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 66 0 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio66/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 66 1 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/gpio/gpio66/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 66 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 67 already exported
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 67 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio67/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 67 0 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio67/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 67 1 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/gpio/gpio67/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 67 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 27 already exported
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 27 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio27/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 27 0 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio27/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 27 1 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: default gpio path
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/gpio/gpio27/value
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 27 OK
Oct 31 04:02:44 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 11 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 11 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio11/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 11 0 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio11/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 11 1 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/gpio/gpio11/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 11 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 61 already exported
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 61 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio61/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 61 0 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio61/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 61 1 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio open_value_file: filename=/sys/class/gpio/gpio61/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 61 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 66 already exported
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 66 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio66/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 66 0 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio66/value
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 66 1 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 66 OK
Oct 31 04:02:45 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 67 already exported
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 67 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio67/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 67 0 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio67/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 67 1 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 67 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 27 already exported
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 27 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio27/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 27 0 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio27/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 27 1 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 27 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 11 already exported
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 11 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio11/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 11 0 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio11/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 11 1 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 11 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_export: 61 already exported
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_direction: 61 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio61/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 61 0 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: default gpio path
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: filename=/sys/class/gpio/gpio61/value
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_set_value: 61 1 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_get_value: 61 OK
Oct 31 04:02:46 beaglebone python[14351]: Adafruit_BBIO: gpio_unexport: 11 OK
```