### PR TITLE
Fix polarity error in PWM.setup() for Linux 4.9

### DIFF
--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -113,7 +113,7 @@ BBIO_err initialize_pwm(void)
         return BBIO_OK;
     }
 
-    syslog(LOG_INFO, "initialize_pwm: OK");
+    syslog(LOG_INFO, "Adafruit_BBIO: initialize_pwm: OK");
     return BBIO_OK;
 }
 
@@ -558,7 +558,7 @@ BBIO_err pwm_setup(const char *key, __attribute__ ((unused)) float duty, __attri
 
 BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
 {
-    syslog(LOG_DEBUG, "pwm_start: %s, %f, %f, %i", key, duty, freq, polarity);
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: %s, %f, %f, %i", key, duty, freq, polarity);
 
     BBIO_err err;
     char buffer[20];
@@ -619,24 +619,24 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
 
     // Initialize pwm->duty to avoid weirdness
     pwm->duty = duty;
-    fprintf(stderr, "pwm_set_frequency()\n");
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: call pwm_set_frequency(key=%s freq=%f)", key, freq);
     err = pwm_set_frequency(key, freq);
     if (err != BBIO_OK) {
         syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't set duty frequency: %i", key, err);
         return err;
     }
 
-    fprintf(stderr, "pwm_set_duty_cycle()\n");
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: call pwm_set_duty_cycle(key=%s duty=%f)", key, duty);
     err = pwm_set_duty_cycle(key, duty);
     if (err != BBIO_OK) {
         syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't set duty cycle: %i", key, err);
         return err;
     }
 
-    fprintf(stderr, "pwm_set_polarity()\n");
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: call pwm_set_polarity(key=%s polarity=%d)", key, polarity);
     err = pwm_set_polarity(key, polarity);
     if (err != BBIO_OK) {
-        syslog(LOG_ERR, "pwm_start: %s couldn't set polarity: %i", key, err);
+        syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't set polarity: %i", key, err);
         return err;
     }
 
@@ -645,7 +645,7 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
         return BBIO_GEN;
     }
     len = snprintf(buffer, sizeof(buffer), "1");
-    fprintf(stderr, "write 1 to pwm->enable_fd\n");
+    syslog(LOG_DEBUG, "Adafruit_BBIO: pwm_start: write(pwm->enable_fd, buffer=%s, len=%d)", buffer, len);
     lseek(pwm->enable_fd, 0, SEEK_SET);
     if (write(pwm->enable_fd, buffer, len) < 0) {
         syslog(LOG_ERR, "Adafruit_BBIO: pwm_start: %s couldn't write enable: %i-%s",

--- a/source/c_pwm.c
+++ b/source/c_pwm.c
@@ -581,12 +581,11 @@ BBIO_err pwm_start(const char *key, float duty, float freq, int polarity)
         return BBIO_GEN;
     }
 
-//FIXME: polarity set broken in v4.9.x/v4.14.x
-//    err = pwm_set_polarity(key, polarity);
-//    if (err != BBIO_OK) {
-//        syslog(LOG_ERR, "pwm_start: %s couldn't set polarity: %i", key, err);
-//        return err;
-//    }
+    err = pwm_set_polarity(key, polarity);
+    if (err != BBIO_OK) {
+        syslog(LOG_ERR, "pwm_start: %s couldn't set polarity: %i", key, err);
+        return err;
+    }
 
     // Read out current period_ns from the file, in order for it to behave
     // properly

--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -238,7 +238,7 @@ int open_value_file(unsigned int gpio)
     // }
 
     if ((fd = open(filename, O_RDONLY | O_NONBLOCK)) < 0) {
-        syslog(LOG_ERR, "gpio open_value_file: %u couldn't open '%s': %i-%s",
+        syslog(LOG_ERR, "Adafruit_BBIO: gpio open_value_file: %u couldn't open '%s': %i-%s",
                gpio, filename, errno, strerror(errno));
         return -1;
     }
@@ -259,7 +259,7 @@ BBIO_err gpio_unexport(unsigned int gpio)
 #define GPIO_UNEXPORT "/sys/class/gpio/unexport"
 
     if ((fd = open(GPIO_UNEXPORT, O_WRONLY)) < 0) {
-      syslog(LOG_ERR, "gpio_unexport: %u couldn't open '"GPIO_UNEXPORT"': %i-%s",
+      syslog(LOG_ERR, "Adafruit_BBIO: gpio_unexport: %u couldn't open '"GPIO_UNEXPORT"': %i-%s",
              gpio, errno, strerror(errno));
       return BBIO_SYSFS;
     }

--- a/test/issue170-pwm.py
+++ b/test/issue170-pwm.py
@@ -1,0 +1,5 @@
+import Adafruit_BBIO.PWM as PWM
+PWM.start("P9_14", 50, 2000, 1)
+PWM.cleanup()
+PWM.start("P9_14", 50, 2000, 0)
+PWM.cleanup()


### PR DESCRIPTION
For issue #170.

Commit 8e08a40f1411378e60e942b4efeb24984203dd50 moved `pwm_set_polarity()` after `pwm_set_frequency()` and `pwm_set_duty_cycle()`.  `PWM.start()` now runs OK after reboot.

Output from running test:
```   
    debian@beaglebone:~/ssh/adafruit-beaglebone-io-python$ sudo python test/issue170-pwm.py; journalctl -p debug -t python --since "1 min ago"
    -- Logs begin at Tue 2017-10-31 06:56:00 UTC, end at Tue 2017-10-31 07:36:39 UTC. --
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: version <unknown> initialized
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, 50.000000, 2000.000000, 1
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: lookup_exported_pwm: couldn't find 'P9_14'
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: initialize_pwm: OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: set_pin_mode() :: Pinmux file /sys/devices/platform/ocp/ocp:P9_14
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: set_pin_mode() :: Set pinmux mode to pwm for P9_14
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, /sys/devices/platform/ocp/48302000.epwmss/48302
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, /sys/devices/platform/ocp/48302000.epwmss/48302
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_setup: P9_14 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_frequency(key=P9_14 freq=2000.000000)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_frequency: P9_14 2000.000000 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_duty_cycle(key=P9_14 duty=50.000000)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_duty_cycle: P9_14 50.000000 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_polarity(key=P9_14 polarity=1)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_polarity: P9_14 1 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: write(pwm->enable_fd, buffer=1, len=1)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14 OK
    Oct 31 07:35:57 beaglebone python[1997]: [40B blob data]
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, 50.000000, 2000.000000, 0
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: lookup_exported_pwm: couldn't find 'P9_14'
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: set_pin_mode() :: Pinmux file /sys/devices/platform/ocp/ocp:P9_14
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: set_pin_mode() :: Set pinmux mode to pwm for P9_14
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, /sys/devices/platform/ocp/48302000.epwmss/48302
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14, /sys/devices/platform/ocp/48302000.epwmss/48302
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_setup: P9_14 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_frequency(key=P9_14 freq=2000.000000)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_frequency: P9_14 2000.000000 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_duty_cycle(key=P9_14 duty=50.000000)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_duty_cycle: P9_14 50.000000 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: call pwm_set_polarity(key=P9_14 polarity=0)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_set_polarity: P9_14 0 OK
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: write(pwm->enable_fd, buffer=1, len=1)
    Oct 31 07:35:57 beaglebone python[1997]: Adafruit_BBIO: pwm_start: P9_14 OK
    Oct 31 07:35:57 beaglebone python[1997]: [40B blob data]

```
