### PR TITLE
Encoder: add logging, move docs to README.md

### DIFF
--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 
-from subprocess import call
+from subprocess import check_output, STDOUT, CalledProcessError
 import os
+import logging
+
 
 class QEP :
 
@@ -48,37 +50,53 @@ class RotaryEncoder(object):
   EQEP1 = 1
   EQEP2 = 2
   EQEP2b = 3
- 
+
+  def _run_cmd(self, cmd):
+    '''Runs a command. If not successful (i.e. error code different than zero),
+    print the stderr output as a warning.
+    '''
+
+    try:
+      output = check_output(cmd, stderr=STDOUT)
+      self._logger.info("_run_cmd(): cmd='{}' return code={} output={}".format(
+        " ".join(cmd), 0, output))
+    except CalledProcessError as e:
+      self._logger.warning(
+        "_run_cmd(): cmd='{}' return code={} output={}".format(
+          " ".join(cmd), e.returncode, e.output))
+
   def config_pin(self, pin):
     '''
     config_pin()
     Config pin for QEP
     '''
-    result = call(["config-pin", pin, "qep"])
-    print("config_pin> pin={0} result={1}".format(pin, result))
-    return result
-  
+
+    self._run_cmd(["config-pin", pin, "qep"])
+
   def cat_file(self, path):
     '''
     cat_file()
     Print contents of file
     '''
-    result = call(["cat", path])
-    print("cat_file> path={0} result={1}".format(path, result))
-    return result
-   
+
+    self._run_cmd(["cat", path])
+
   def __init__(self, eqep_num):
     '''
     RotaryEncoder(eqep_num)
-    Creates an instance of the class RotaryEncoder. 
-    eqep_num determines which eQEP pins are set up. 
+    Creates an instance of the class RotaryEncoder.
+    eqep_num determines which eQEP pins are set up.
     eqep_num can be: EQEP0, EQEP1, EQEP2 or EQEP2b based on which pins \
     the rotary encoder is connected to.
     '''
-    print(">>>>>>>> TEST CALL BEGIN")
 
-    ###################################
-    print(">>>>>> eqep0: P9_27, P9_92")
+    self._logger = logging.getLogger(__name__)
+    self._logger.addHandler(logging.NullHandler())
+    #self._logger.setLevel(logging.DEBUG)
+
+    # Configure eqep0
+    self._logger.info("Configuring eqep0, pins: P9.27, P9.92")
+
     pin = "P9_27"
     self.config_pin(pin)
 
@@ -86,10 +104,10 @@ class RotaryEncoder(object):
     self.config_pin(pin)
 
     path = "/sys/devices/platform/ocp/48300000.epwmss/48300180.eqep/position"
-    self.cat_file(path);
+    self.cat_file(path)
 
-    ###################################
-    print(">>>>>>> eqep1: P8.33, P8.35")
+    # Configure eqep1
+    self._logger.info("Configuring eqep1, pins: P8.33, P8.35")
 
     pin = "P8.33"
     self.config_pin(pin)
@@ -100,8 +118,8 @@ class RotaryEncoder(object):
     path = "/sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position"
     self.cat_file(path);
 
-    ###################################
-    print(">>>>>>> eqep2: P8.11, P8.12")
+    # Configure eqep2
+    self._logger.info("Configuring eqep2, pins: P8.11, P8.12")
 
     pin = "P8.11"
     self.config_pin(pin)
@@ -112,8 +130,8 @@ class RotaryEncoder(object):
     path = "/sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position"
     self.cat_file(path);
 
-    ###################################
-    print(">>>>>>> eqep2b: P8.41, P8.42")
+    # Configure eqep2b
+    self._logger.info("Configuring eqep2, pins: P8.41, P8.42")
 
     pin = "P8.41"
     self.config_pin(pin)
@@ -124,17 +142,17 @@ class RotaryEncoder(object):
     path = "/sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position"
     self.cat_file(path);
 
-    ###################################
-    print(">>>>>>>> TEST CALL END")
+    self._logger.debug("RotaryEncoder(): eqep_num: {0}".format(eqep_num))
+    self._logger.debug("RotaryEncoder(): self._eqep_dirs[0]: {0}".format(self._eqep_dirs[0]))
+    self._logger.debug("RotaryEncoder(): self._eqep_dirs[1]: {0}".format(self._eqep_dirs[1]))
+    self._logger.debug("RotaryEncoder(): self._eqep_dirs[2]: {0}".format(self._eqep_dirs[2]))
+    self._logger.debug("RotaryEncoder(): self._eqep_dirs[eqep_num: {0}]: {1}".format(eqep_num, self._eqep_dirs[eqep_num]))
 
-    print("RotaryEncoder(): eqep_num: {0}".format(eqep_num))
-    print("RotaryEncoder(): self._eqep_dirs[0]: {0}".format(self._eqep_dirs[0]))
-    print("RotaryEncoder(): self._eqep_dirs[1]: {0}".format(self._eqep_dirs[1]))
-    print("RotaryEncoder(): self._eqep_dirs[2]: {0}".format(self._eqep_dirs[2]))
-    print("RotaryEncoder(): self._eqep_dirs[eqep_num: {0}]: {1}".format(eqep_num, self._eqep_dirs[eqep_num]))
     assert 0 <= eqep_num <= 3 , "eqep_num must be between 0 and 3"
+
     self.base_dir = self._eqep_dirs[eqep_num]
-    print("RotaryEncoder(): self.base_dir: {0}".format(self.base_dir))
+    self._logger.debug("RotaryEncoder(): self.base_dir: {0}".format(self.base_dir))
+
     self.enable()
 
   def enable(self):
@@ -143,32 +161,35 @@ class RotaryEncoder(object):
     Turns the eQEP hardware ON
     '''
     enable_file = "%s/enabled" % self.base_dir
-    print("enable(): enable_file: {0}".format(enable_file))
-    print("enable(): TODO: write 1 to enable_file")
-    #return sysfs.kernelFileIO(enable_file, '1') 
-    
+    self._logger.debug("enable(): enable_file: {0}".format(enable_file))
+    self._logger.warning(
+      "enable(): TODO: not implemented, write 1 to {}".format(enable_file))
+    #return sysfs.kernelFileIO(enable_file, '1')
+
   def disable(self):
     '''
     disable()
     Turns the eQEP hardware OFF
     '''
     enable_file = "%s/enabled" % self.base_dir
-    print("disable(): enable_file: {0}".format(enable_file))
-    print("disable(): TODO: write 0 to enable_file")
+    self._logger.debug("disable(): enable_file: {0}".format(enable_file))
+    self._logger.warning(
+      "disable(): TODO: not implemented, write 0 to {}".format(enable_file))
     #return sysfs.kernelFileIO(enable_file, '0')
 
   def setAbsolute(self):
     '''
     setAbsolute()
     Set mode as Absolute
-    The position starts at zero and is incremented or 
+    The position starts at zero and is incremented or
     decremented by the encoder's movement
     '''
     mode_file = "%s/mode" % self.base_dir
-    print("setAbsolute(): mode_file: {0}".format(mode_file))
-    print("setAbsolute(): TODO: write 0 to mode_file")
+    self._logger.debug("setAbsolute(): mode_file: {0}".format(mode_file))
+    self._logger.warning(
+      "setAbsolute(): TODO: not implemented, write 0 to {}".format(mode_file))
     #return sysfs.kernelFileIO(mode_file, '0')
-    
+
   def setRelative(self):
     '''
     setRelative()
@@ -176,60 +197,66 @@ class RotaryEncoder(object):
     The position is reset when the unit timer overflows.
     '''
     mode_file = "%s/mode" % self.base_dir
-    print("setRelative(): mode_file: {0}".format(mode_file))
-    print("setRelative(): TODO: write 1 to mode_file")
+    self._logger.debug("setRelative(): mode_file: {0}".format(mode_file))
+    self._logger.warning(
+      "setRelative(): TODO: not implemented, write 1 to {}".format(mode_file))
     #return sysfs.kernelFileIO(mode_file, '1')
-    
+
   def getMode(self):
     '''
     getMode()
     Returns the mode the eQEP hardware is in.
     '''
     mode_file = "%s/mode" % self.base_dir
-    print("getMode(): mode_file: {0}".format(mode_file))
-    print("getMode(): TODO: read mode_file")
+    self._logger.debug("getMode(): mode_file: {0}".format(mode_file))
+    self._logger.warning("getMode(): TODO: read mode_file")
     #return sysfs.kernelFileIO(mode_file)
 
   def getPosition(self):
     '''
     getPosition()
     Get the current position of the encoder.
-    In absolute mode, this attribute represents the current position 
-    of the encoder. 
-    In relative mode, this attribute represents the position of the 
+    In absolute mode, this attribute represents the current position
+    of the encoder.
+    In relative mode, this attribute represents the position of the
     encoder at the last unit timer overflow.
     '''
     position_file = "%s/position" % self.base_dir
-    print("getPosition(): position_file: {0}".format(position_file))
+    self._logger.debug("getPosition(): position_file: {0}".format(position_file))
     position_handle = open(position_file, 'r')
-    print("getPosition(): position_handle: {0}".format(position_handle))
+    self._logger.debug("getPosition(): position_handle: {0}".format(position_handle))
     position = position_handle.read()
-    print("getPosition(): position: {0}".format(position))
+    self._logger.debug("getPosition(): position: {0}".format(position))
     #return sysfs.kernelFileIO(position_file)
+
     return position
-    
-  def setFrequency(self,freq):
+
+  def setFrequency(self, freq):
     '''
     setFrequency(freq)
     Set the frequency in Hz at which the driver reports new positions.
     '''
     period_file = "%s/period" % self.base_dir
-    print("setFrequency(): period_file: {0}".format(period_file))
-    print("setFrequency(): freq: {0}".format(period_file))
-    print("setFrequency(): freq: {0}".format(freq))
-    print("setFrequency(): 1000000000/freq: {0}".format(1000000000/freq))
-    print("setFrequency(): str(1000000000/freq)): {0}".format(str(1000000000/freq)))
-    print("setFrequency(): TODO: set period_file: {0}".format(str(1000000000/freq)))
+    self._logger.debug("setFrequency(): period_file: {0}".format(period_file))
+    self._logger.debug("setFrequency(): freq: {0}".format(freq))
+    self._logger.debug("setFrequency(): 1000000000/freq: {0}".format(1000000000/freq))
+    self._logger.debug("setFrequency(): str(1000000000/freq)): {0}".format(str(1000000000/freq)))
+    self._logger.warning(
+      "setFrequency(): TODO: not implemented, set {} to {}".format(
+        period_file, str(1000000000/freq)))
     #return sysfs.kernelFileIO(period_file, str(1000000000/freq))
-    
-  def setPosition(self,val):
-    ''' 
+
+  def setPosition(self, val):
+    '''
     setPosition(value)
     Give a new value to the current position
     '''
     position_file = "%s/position" % self.base_dir
+    self._logger.warning(
+      "setPosition(): TODO: not implemented, write position to {}".format(
+        position_file))
     #return sysfs.kernelFileIO(position_file, str(val))
-    
+
   def zero(self):
     '''
     zero()s
@@ -239,7 +266,7 @@ class RotaryEncoder(object):
 
 
 #"""
-# encoder_test.py 
+# encoder_test.py
 # Rekha Seethamraju
 # An example to demonstrate the use of the eQEP library
 # for PyBBIO.
@@ -253,9 +280,9 @@ class RotaryEncoder(object):
 #def setup():
 #  encoder.setAbsolute()
 #  encoder.zero()
-#  
+#
 #def loop():
 #  print("encoder position : "+encoder.getPosition())
 #  delay(1000)
-#  
+#
 #run(setup, loop)

--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -92,7 +92,6 @@ class RotaryEncoder(object):
 
     self._logger = logging.getLogger(__name__)
     self._logger.addHandler(logging.NullHandler())
-    #self._logger.setLevel(logging.DEBUG)
 
     # Configure eqep0
     self._logger.info("Configuring eqep0, pins: P9.27, P9.92")

--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -1,57 +1,5 @@
 #!/usr/bin/python
 
-# ===========================================================================
-# Adafruit_BBIO.Encoder Class
-# ===========================================================================
-# refers to graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py
-
-# BeagleBone must boot with cape-universal enabled
-# and load the cape-universala overlay in order to
-# use all the eQEP pins
-#
-# Install the latest Device Tree overlays:
-# ========================================
-# sudo apt-get upgrade bb-cape-overlays
-#
-# File: /boot/uEnv.txt
-# ====================
-# uname_r=4.4.62-ti-r99
-# cmdline=coherent_pool=1M quiet cape_universal=enable
-# cape_enable=bone_capemgr.enable_partno=cape-universala
-#
-# File: /sys/devices/platform/bone_capemgr/slots
-# ==============================================
-# 0: PF----  -1 
-# 1: PF----  -1 
-# 2: PF----  -1 
-# 3: PF----  -1 
-# 4: P-O-L-   0 Override Board Name,00A0,Override Manuf,cape-universala
-#
-# eqep0: P9_27, P9_92
-# ===================
-# config-pin P9_27 qep
-# config-pin P9_92 qep # alias for P9_42.1
-# cat /sys/devices/platform/ocp/48300000.epwmss/48300180.eqep/position
-#
-# eqep1: P8.33, P8.35
-# ===================
-# config-pin P8.33 qep 
-# config-pin P8.35 qep
-# cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
-# 
-# eqep2: P8.11, P8.12
-# ===================
-# config-pin P8.11 qep 
-# config-pin P8.12 qep 
-# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
-#
-# alternate pins for eqep2 (mutually exclusive)
-# eqep2b: P8.41, P8.42
-# ====================
-# config-pin P8.41 qep 
-# config-pin P8.42 qep 
-# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
-
 from subprocess import call
 import os
 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -2,7 +2,7 @@
 
 Initially based on the [PyBBIO](https://github.com/graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py) rotary encoder code.
 
-This module enables access to the Beaglebone's enhanced Quadrature Encoder Pulse (eQEP) inputs.
+This module enables access to the Beaglebone Black enhanced Quadrature Encoder Pulse (eQEP) modules: eQEP0, eQEP1 and eQEP2.
 
 ## Prerequisites
 
@@ -38,6 +38,8 @@ TBD
 
 ## eQEP configuraton
 
+Note: if either eQEP 1 or eQEP 2 are used on the Beaglebone Black, video must be disabled, as their pins are shared with the LCD_DATAx lines of the HDMI interface.
+
 ### eQEP0
 
 Pins: `P9_27`, `P9_92`
@@ -60,6 +62,8 @@ $ cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
 
 ### eQEP2
 
+#### eQEP2
+
 Pins: `P8.11`, `P8.12`
 
 ```
@@ -68,7 +72,7 @@ $ config-pin P8.12 qep
 $ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
 ```
 
-### eQEP2b
+#### eQEP2b
 
 Note: alternate pins for eQEP2 (mutually exclusive)
 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -1,21 +1,21 @@
 # Adafruit_BBIO.Encoder module
 
-Initially based on the [PyBBIO](https://github.com/graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py) rotary encoder code.
-
 This module enables access to the Beaglebone Black enhanced Quadrature Encoder Pulse (eQEP) modules: eQEP0, eQEP1 and eQEP2.
+
+Initially based on the [PyBBIO](https://github.com/graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py) rotary encoder code.
 
 ## Prerequisites
 
 These instructions are based on a 4.4.x Linux kernel.
 
-In order to use all eQEP pins the BeagleBone must:
+In order to use all eQEP pins the BeagleBone must boot with the [cape-universal](https://github.com/beagleboard/bb.org-overlays/tree/master/tools/beaglebone-universal-io) enabled, and load the cape-universal overlay
 
-1. boot with cape-universal enabled, and
-2. load the cape-universala overlay
+```
+enable_uboot_cape_universal=1
+```
 
 Notes:
-- It would seem that `cape_universal` is [enabled by default already](https://groups.google.com/d/msg/beagleboard/2D5Pz3r7ZZ8/bLKcvHbGDgAJ) from kernel 4.1.x onwards. As such, the first step is not necessary.
-- An alternative option to the `cape-universala` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
+- An alternative option to the `cape-universal` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
 
 ### Install/upgrade the latest Device Tree overlays
 
@@ -25,23 +25,27 @@ sudo apt-get upgrade bb-cape-overlays
 
 ### Load the universal cape
 
-Modify the `/boot/uEnv.txt` file to contain these two lines: 
+If it doesn't already contain it, modify the `/boot/uEnv.txt` file to contain this line: 
 
 ```
-cmdline=coherent_pool=1M net.ifnames=0 quiet cape_universal=enable
+enable_uboot_cape_universal=1
 ```
 
-```
-cape_enable=bone_capemgr.enable_partno=cape-universala
-```
+Notes:
 
-### Check slots
+- Some older documentation recommends using these two lines instead. They are meant to load deprecated kernel-based overlays and it's not recommended to use them. Use the new way of [loading overlays via uboot](https://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays) instead, as instructed above.
 
-TBD
+  ```
+  cmdline=cape_universal=enable # Plus some other options
+  ```
+  ```
+  cape_enable=bone_capemgr.enable_partno=cape-universala
+  ```
+- TBD: check the overlays that are currently loaded
 
 ## eQEP configuraton
 
-Note: if either eQEP 1 or eQEP 2 are used on the Beaglebone Black, video must be disabled, as their pins are shared with the LCD_DATAx lines of the HDMI interface.
+Note: if either eQEP1 or eQEP2b are used on the Beaglebone Black, video must be disabled, as their pins are shared with the LCD_DATAx lines of the HDMI interface.
 
 ### eQEP0
 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -10,10 +10,12 @@ These instructions are based on a 4.4.x Linux kernel.
 
 In order to use all eQEP pins the BeagleBone must:
 
-- boot with cape-universal enabled, and
-- load the cape-universala overlay
+1. boot with cape-universal enabled, and
+2. load the cape-universala overlay
 
-Note: an alternative option to the `cape-universala` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
+Notes:
+- It would seem that `cape_universal` is [enabled by default already](https://groups.google.com/d/msg/beagleboard/2D5Pz3r7ZZ8/bLKcvHbGDgAJ) from kernel 4.1.x onwards. As such, the first step is not necessary.
+- An alternative option to the `cape-universala` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
 
 ### Install/upgrade the latest Device Tree overlays
 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -15,6 +15,7 @@ enable_uboot_cape_universal=1
 ```
 
 Notes:
+- It seems that the `cape-universal` cape _does only enable access to eQEP0 and eQEP2_. TBD: check how to load [`cape-universala`](https://github.com/cdsteinkuehler/beaglebone-universal-io/pull/30)
 - An alternative option to the `cape-universal` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
 
 ### Install/upgrade the latest Device Tree overlays

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -1,6 +1,8 @@
-# Adafruit_BBIO.Encoder Class
+# Adafruit_BBIO.Encoder module
 
 Initially based on the [PyBBIO](https://github.com/graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py) rotary encoder code.
+
+This module enables access to the Beaglebone's enhanced Quadrature Encoder Pulse (eQEP) inputs.
 
 ## Prerequisites
 
@@ -70,7 +72,7 @@ $ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
 
 Note: alternate pins for eQEP2 (mutually exclusive)
 
-Pins: `P8.11`, `P8.12`
+Pins: `P8.41`, `P8.42`
 
 ```
 $ config-pin P8.41 qep 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -13,6 +13,7 @@ In order to use all eQEP pins the BeagleBone must:
 - boot with cape-universal enabled, and
 - load the cape-universala overlay
 
+Note: an alternative option to the `cape-universala` overlay would be to load one of the [dedicated eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts). 
 
 ### Install/upgrade the latest Device Tree overlays
 
@@ -83,3 +84,7 @@ $ config-pin P8.41 qep
 $ config-pin P8.42 qep
 $ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
 ```
+## Further reading
+
+- [Beaglebone encoder inputs](https://github.com/Teknoman117/beaglebot/tree/master/encoders)
+- [Beaglebone eQEP overlays](https://github.com/Teknoman117/beaglebot/tree/master/encoders/dts)

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -58,7 +58,7 @@ $ cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
 
 ### eQEP2
 
-Pins: `P8.11, P8.12
+Pins: `P8.11`, `P8.12`
 
 ```
 $ config-pin P8.11 qep 
@@ -69,7 +69,8 @@ $ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
 ### eQEP2b
 
 Note: alternate pins for eQEP2 (mutually exclusive)
-Pins: `P8.11, P8.12
+
+Pins: `P8.11`, `P8.12`
 
 ```
 $ config-pin P8.41 qep 

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -1,51 +1,78 @@
-# ===========================================================================
 # Adafruit_BBIO.Encoder Class
-# ===========================================================================
-# refers to graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py
 
-# BeagleBone must boot with cape-universal enabled
-# and load the cape-universala overlay in order to
-# use all the eQEP pins
-#
-# Install the latest Device Tree overlays:
-# ========================================
-# sudo apt-get upgrade bb-cape-overlays
-#
-# File: /boot/uEnv.txt
-# ====================
-# uname_r=4.4.62-ti-r99
-# cmdline=coherent_pool=1M quiet cape_universal=enable
-# cape_enable=bone_capemgr.enable_partno=cape-universala
-#
-# File: /sys/devices/platform/bone_capemgr/slots
-# ==============================================
-# 0: PF----  -1 
-# 1: PF----  -1 
-# 2: PF----  -1 
-# 3: PF----  -1 
-# 4: P-O-L-   0 Override Board Name,00A0,Override Manuf,cape-universala
-#
-# eqep0: P9_27, P9_92
-# ===================
-# config-pin P9_27 qep
-# config-pin P9_92 qep # alias for P9_42.1
-# cat /sys/devices/platform/ocp/48300000.epwmss/48300180.eqep/position
-#
-# eqep1: P8.33, P8.35
-# ===================
-# config-pin P8.33 qep 
-# config-pin P8.35 qep
-# cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
-# 
-# eqep2: P8.11, P8.12
-# ===================
-# config-pin P8.11 qep 
-# config-pin P8.12 qep 
-# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
-#
-# alternate pins for eqep2 (mutually exclusive)
-# eqep2b: P8.41, P8.42
-# ====================
-# config-pin P8.41 qep 
-# config-pin P8.42 qep 
-# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
+Initially based on the [PyBBIO](https://github.com/graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py) rotary encoder code.
+
+## Prerequisites
+
+These instructions are based on a 4.4.x Linux kernel.
+
+In order to use all eQEP pins the BeagleBone must:
+
+- boot with cape-universal enabled, and
+- load the cape-universala overlay
+
+
+### Install/upgrade the latest Device Tree overlays
+
+```
+sudo apt-get upgrade bb-cape-overlays
+```
+
+### Load the universal cape
+
+Modify the `/boot/uEnv.txt` file to contain these two lines: 
+
+```
+cmdline=coherent_pool=1M net.ifnames=0 quiet cape_universal=enable
+```
+
+```
+cape_enable=bone_capemgr.enable_partno=cape-universala
+```
+
+### Check slots
+
+TBD
+
+## eQEP configuraton
+
+### eQEP0
+
+Pins: `P9_27`, `P9_92`
+
+```
+$ config-pin P9_27 qep
+$ config-pin P9_92 qep # alias for P9_42.1
+$ cat /sys/devices/platform/ocp/48300000.epwmss/48300180.eqep/position
+```
+
+### eQEP1
+
+Pins: `P8.33`, `P8.35`
+
+```
+$ config-pin P8.33 qep
+$ config-pin P8.35 qep
+$ cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
+```
+
+### eQEP2
+
+Pins: `P8.11, P8.12
+
+```
+$ config-pin P8.11 qep 
+$ config-pin P8.12 qep
+$ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
+```
+
+### eQEP2b
+
+Note: alternate pins for eQEP2 (mutually exclusive)
+Pins: `P8.11, P8.12
+
+```
+$ config-pin P8.41 qep 
+$ config-pin P8.42 qep
+$ cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
+```

--- a/Adafruit_BBIO/README.md
+++ b/Adafruit_BBIO/README.md
@@ -1,0 +1,51 @@
+# ===========================================================================
+# Adafruit_BBIO.Encoder Class
+# ===========================================================================
+# refers to graycatlabs/PyBBIO/bbio/libraries/RotaryEncoder/rotary_encoder.py
+
+# BeagleBone must boot with cape-universal enabled
+# and load the cape-universala overlay in order to
+# use all the eQEP pins
+#
+# Install the latest Device Tree overlays:
+# ========================================
+# sudo apt-get upgrade bb-cape-overlays
+#
+# File: /boot/uEnv.txt
+# ====================
+# uname_r=4.4.62-ti-r99
+# cmdline=coherent_pool=1M quiet cape_universal=enable
+# cape_enable=bone_capemgr.enable_partno=cape-universala
+#
+# File: /sys/devices/platform/bone_capemgr/slots
+# ==============================================
+# 0: PF----  -1 
+# 1: PF----  -1 
+# 2: PF----  -1 
+# 3: PF----  -1 
+# 4: P-O-L-   0 Override Board Name,00A0,Override Manuf,cape-universala
+#
+# eqep0: P9_27, P9_92
+# ===================
+# config-pin P9_27 qep
+# config-pin P9_92 qep # alias for P9_42.1
+# cat /sys/devices/platform/ocp/48300000.epwmss/48300180.eqep/position
+#
+# eqep1: P8.33, P8.35
+# ===================
+# config-pin P8.33 qep 
+# config-pin P8.35 qep
+# cat /sys/devices/platform/ocp/48302000.epwmss/48302180.eqep/position
+# 
+# eqep2: P8.11, P8.12
+# ===================
+# config-pin P8.11 qep 
+# config-pin P8.12 qep 
+# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position
+#
+# alternate pins for eqep2 (mutually exclusive)
+# eqep2b: P8.41, P8.42
+# ====================
+# config-pin P8.41 qep 
+# config-pin P8.42 qep 
+# cat /sys/devices/platform/ocp/48304000.epwmss/48304180.eqep/position


### PR DESCRIPTION
Add logging support to the Encoder module and turn off unconditional debug output. To use, add the following statements to any application that uses the module:

```
import logging
logging.basicConfig(level=logging.INFO)
```
To see more verbose output, `logging.DEBUG` can be used. Refer to the [Python logging module documentation](https://docs.python.org/2/library/logging.html) for more info.

The module was also lightly cleaned up by moving the instructions to set up QEP to a separate README.md file for an easier read and maintenance.