### PR TITLE
Encoder: corrected kernel check logic

### DIFF
--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -6,7 +6,8 @@ import logging
 import itertools
 import platform
 
-if not platform.release().startswith('4.4'):
+(major, minor, patch) = platform.release().split("-")[0].split(".")
+if not (int(major) >= 4 and int(minor) >=  4):
     raise ImportError(
         'The Encoder module requires Linux kernel version >= 4.4.x.\n'
         'Please upgrade your kernel to use this module.\n'


### PR DESCRIPTION
This change fixes the logic for checking if the kernel version is >= 4.4.x to use the Encoder module.

Previously the check would fail for kernels > 4.4.x.

Another alternative implementation would be to use [`LooseVersion` from `distutils.version`](https://stackoverflow.com/a/11887885/1049318)