### PR TITLE
Encoder: fix frequency calculation from period

### DIFF
--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -271,12 +271,13 @@ class RotaryEncoder(object):
         new positions.
 
         '''
-        frequency = self._eqep.node.period / self._NS_FACTOR
+        frequency = self._NS_FACTOR / int(self._eqep.node.period) 
 
         self._logger.debug(
             "Set frequency(): Channel {}, frequency: {} Hz, "
             "period: {} ns".format(
-                self._eqep.channel, frequency, period))
+                self._eqep.channel, frequency,
+                self._eqep.node.period))
 
         return frequency
 

--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -47,7 +47,7 @@ class eQEP(object):
         '''Creates a class instance from a dictionary'''
 
         allowed = ('channel', 'pin_A', 'pin_B', 'sys_path')
-        df = {k: v for k, v in d.iteritems() if k in allowed}
+        df = {k: v for k, v in d.items() if k in allowed}
         return cls(**df)
 
     def __init__(self, channel, pin_A, pin_B, sys_path):

--- a/Adafruit_BBIO/Encoder.py
+++ b/Adafruit_BBIO/Encoder.py
@@ -4,7 +4,7 @@ from subprocess import check_output, STDOUT, CalledProcessError
 import os
 import logging
 import itertools
-import sysfs
+from .sysfs import Node
 import platform
 
 (major, minor, patch) = platform.release().split("-")[0].split(".")
@@ -72,7 +72,7 @@ class eQEP(object):
         self.pin_A = pin_A
         self.pin_B = pin_B
         self.sys_path = sys_path
-        self.node = sysfs.Node(sys_path)
+        self.node = Node(sys_path)
 
 
 class RotaryEncoder(object):


### PR DESCRIPTION
This change fixes the following:
- Correct calculation of the frequency from period on the property getter
- Cast the string returned from sysfs to int to perform the calculation
- Fix the period variable for logging and debug properties

The change builds upon PR #212 and fixes issue #211 