### PR TITLE
* Fixed  SEGFAULT when calling remove_event_detect() from python callback

### DIFF
--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -562,9 +562,11 @@ void run_callbacks(unsigned int gpio)
     struct callback *cb = callbacks;
     while (cb != NULL)
     {
-        if (cb->gpio == gpio)
+        if (cb->gpio == gpio) 
             cb->func(cb->gpio);
-        cb = cb->next;
+        // Current callback pointer might have changed _only_ if linked list structure has been altered from within the callback function, which should happen _only_ in remove_event_detect() call
+        if (cb != NULL)
+            cb = cb->next;
     }
 }
 


### PR DESCRIPTION
There is an old issue with the library which results in SEGFAULT if remove_event_detect() function is called from within the python callback. 
More information can be found here:
https://sourceforge.net/p/raspberry-gpio-python/tickets/136/
https://raspberrypi.stackexchange.com/questions/73791/gpio-callbacks-throw-segmentation-fault
https://stackoverflow.com/questions/35632689/how-to-correctly-remove-interrupt-callback-in-beaglebone-black
http://schlierf.info/raspberry/pi/gpio/python/2016/04/15/RPi.GPIO_SegFault.html

The origin of the problem is the way of handling callbacks - C code stores them in a linked list structure, and, while it correctly removes/inserts new items it doesn't do any sanity checks inside the wrapper that iterates over the list. That results in dereferencing zero pointer if last callback in the chain was removed inside the callback function.
I provide a possible solution to this. Two places need to be patched. While the base C code (_event_gpio.c_) requires only minor alteration to prevent SEGFAULTs, upper-level python library (_py_gpio.c_) needs a bit more elaborate workaround to stop traversing the callback chain immediately if event detection was removed while running one of the callback functions.
Typical example when this functionality might be needed is programming interrupt-like behavior with event detection system (see 3rd link above).