### PR TITLE
Update UART examples

### DIFF
--- a/Adafruit_BBIO/sysfs.py
+++ b/Adafruit_BBIO/sysfs.py
@@ -41,7 +41,7 @@ Usage examples::
 
     # Print all block devices in /sys, with their sizes
     for block_dev in sys.block:
-        print block_dev, str(int(block_dev.size) / 1048576) + ' M'
+        print(block_dev, str(int(block_dev.size) / 1048576) + ' M')
 
     >>> import sysfs
     >>> # Read/write Beaglebone Black's eQEP module attributes

--- a/README.md
+++ b/README.md
@@ -198,13 +198,10 @@ import serial
 
 UART.setup("UART1")
 
-ser = serial.Serial(port = "/dev/ttyO1", baudrate=9600)
-ser.close()
-ser.open()
-if ser.isOpen():
+with serial.Serial(port = "/dev/ttyO1", baudrate=9600) as ser:
     print("Serial is open!")
-    ser.write("Hello World!")
-ser.close()
+    ser.write(b"Hello World!")
+
 ```
 * Available UART names on BeagleBone
   * `UART1`: /dev/ttyO1, Rx: P9_26, Tx: P9_24

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Detecting events:
     #your amazing code here 
     #detect wherever: 
     if GPIO.event_detected("P9_12"):
-      print "event detected!"
+      print("event detected!")
 
 ### PWM
 **The PWM Duty Cycle range was reversed in 0.0.15 from 100(off)-0(on) to 0(off)-100(on).  Please update your code accordingly.**
@@ -202,7 +202,7 @@ ser = serial.Serial(port = "/dev/ttyO1", baudrate=9600)
 ser.close()
 ser.open()
 if ser.isOpen():
-    print "Serial is open!"
+    print("Serial is open!")
     ser.write("Hello World!")
 ser.close()
 ```

--- a/docs/UART.rst
+++ b/docs/UART.rst
@@ -14,13 +14,9 @@ Example::
 
     UART.setup("UART1")
 
-    ser = serial.Serial(port = "/dev/ttyO1", baudrate=9600)
-    ser.close()
-    ser.open()
-    if ser.isOpen():
-	 print "Serial is open!"
-         ser.write("Hello World!")
-    ser.close()
+    with serial.Serial(port = "/dev/ttyO1", baudrate=9600) as ser:
+        print("Serial is open!")
+        ser.write(b"Hello World!")
 
 .. module:: Adafruit_BBIO.UART
 

--- a/source/examples/python/i2ctmp101.py
+++ b/source/examples/python/i2ctmp101.py
@@ -8,5 +8,5 @@ address = 0x49
 
 while True:
     temp = bus.read_byte_data(address, 0)
-    print (temp, end="\r")
+    print(temp, end="\r")
     time.sleep(0.25)

--- a/test/notes/spi_loopback_test.md
+++ b/test/notes/spi_loopback_test.md
@@ -46,7 +46,7 @@ from Adafruit_BBIO.SPI import SPI
 #spi = SPI(1,1)	#/dev/spidev2.1
 
 spi = SPI(0,0) 
-print spi.xfer2([32, 11, 110, 22, 220]) 
+print(spi.xfer2([32, 11, 110, 22, 220]))
 spi.close() 
 ```
 

--- a/test/start_all_pwm.py
+++ b/test/start_all_pwm.py
@@ -20,7 +20,7 @@ pins = [
 # /sys/devices/platform/ocp/48304000.epwmss/48304100.ecap/pwm/pwmchip5/pwm-5:0/duty_cycle
 
 for pin in pins:
-  print pin
+  print(pin)
   PWM.start(pin, 50, 2000, 1)
   PWM.stop(pin)
   PWM.cleanup()


### PR DESCRIPTION
The UART example was using the older pySerial API which was deprecated in v3.0. I have updated the example code to use the context-manager API which is clearer, shorter, and less error-prone.

I've also gone through and updated the remaining `print` statements to `print()` function calls while I was in there.