### PR TITLE
UART4 added to Pocketbeagle

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -271,6 +271,8 @@ pins_t table[] = {
 //   P2_09 uart1_txd
 //   P1_08 uart2_rxd
 //   P1_10 uart2_txd
+//   P2_05 uart4_rxd
+//   P2_07 uart4_txd 
 
 uart_t uart_table[] = {
   { "UART1", "/dev/ttyO1", "ADAFRUIT-UART1", "P9_26", "P9_24"},
@@ -281,6 +283,7 @@ uart_t uart_table[] = {
   { "PB-UART0", "/dev/ttyO0", "ADAFRUIT-UART0", "P1_30", "P1_32"},
   { "PB-UART1", "/dev/ttyO1", "ADAFRUIT-UART1", "P2_11", "P2_09"},
   { "PB-UART2", "/dev/ttyO2", "ADAFRUIT-UART2", "P1_08", "P1_10"},
+    "PB-UART4", "/dev/ttyO4", "ADAFRUIT-UART4", "P2_05", "P2_07"},
   { NULL, NULL, 0, 0, 0 }
 };
 

--- a/source/common.c
+++ b/source/common.c
@@ -283,7 +283,7 @@ uart_t uart_table[] = {
   { "PB-UART0", "/dev/ttyO0", "ADAFRUIT-UART0", "P1_30", "P1_32"},
   { "PB-UART1", "/dev/ttyO1", "ADAFRUIT-UART1", "P2_11", "P2_09"},
   { "PB-UART2", "/dev/ttyO2", "ADAFRUIT-UART2", "P1_08", "P1_10"},
-    "PB-UART4", "/dev/ttyO4", "ADAFRUIT-UART4", "P2_05", "P2_07"},
+  { "PB-UART4", "/dev/ttyO4", "ADAFRUIT-UART4", "P2_05", "P2_07"},
   { NULL, NULL, 0, 0, 0 }
 };
 


### PR DESCRIPTION
Added one additional UART entry for the pocketbeagle board in common.c file.  Confirmed to be working by testing on a pocketbeagle with jumpers on the UART4's TX and RX to talk to itself. 

pocketbeagle UART4 pins:  
P2_05 uart4_rxd
P2_07 uart4_txd  
