### PR TITLE
fix link error due multiple variables definitions

### DIFF
--- a/source/constants.c
+++ b/source/constants.c
@@ -35,39 +35,41 @@ SOFTWARE.
 
 void define_constants(PyObject *module)
 {
-   high = Py_BuildValue("i", HIGH);
-   PyModule_AddObject(module, "HIGH", high);
+   PyObject *object;
 
-   low = Py_BuildValue("i", LOW);
-   PyModule_AddObject(module, "LOW", low);
+   object = Py_BuildValue("i", HIGH);
+   PyModule_AddObject(module, "HIGH", object);
 
-   output = Py_BuildValue("i", OUTPUT);
-   PyModule_AddObject(module, "OUT", output);
+   object = Py_BuildValue("i", LOW);
+   PyModule_AddObject(module, "LOW", object);
 
-   input = Py_BuildValue("i", INPUT);
-   PyModule_AddObject(module, "IN", input);   
+   object = Py_BuildValue("i", OUTPUT);
+   PyModule_AddObject(module, "OUT", object);
 
-   alt0 = Py_BuildValue("i", ALT0);
-   PyModule_AddObject(module, "ALT0", alt0);
+   object = Py_BuildValue("i", INPUT);
+   PyModule_AddObject(module, "IN", object);
 
-   pud_off = Py_BuildValue("i", PUD_OFF);
-   PyModule_AddObject(module, "PUD_OFF", pud_off);
+   object = Py_BuildValue("i", ALT0);
+   PyModule_AddObject(module, "ALT0", object);
 
-   pud_up = Py_BuildValue("i", PUD_UP);
-   PyModule_AddObject(module, "PUD_UP", pud_up);
+   object = Py_BuildValue("i", PUD_OFF);
+   PyModule_AddObject(module, "PUD_OFF", object);
 
-   pud_down = Py_BuildValue("i", PUD_DOWN);
-   PyModule_AddObject(module, "PUD_DOWN", pud_down);
+   object = Py_BuildValue("i", PUD_UP);
+   PyModule_AddObject(module, "PUD_UP", object);
+
+   object = Py_BuildValue("i", PUD_DOWN);
+   PyModule_AddObject(module, "PUD_DOWN", object);
    
-   rising_edge = Py_BuildValue("i", RISING_EDGE);
-   PyModule_AddObject(module, "RISING", rising_edge);
+   object = Py_BuildValue("i", RISING_EDGE);
+   PyModule_AddObject(module, "RISING", object);
    
-   falling_edge = Py_BuildValue("i", FALLING_EDGE);
-   PyModule_AddObject(module, "FALLING", falling_edge);
+   object = Py_BuildValue("i", FALLING_EDGE);
+   PyModule_AddObject(module, "FALLING", object);
 
-   both_edge = Py_BuildValue("i", BOTH_EDGE);
-   PyModule_AddObject(module, "BOTH", both_edge);
+   object = Py_BuildValue("i", BOTH_EDGE);
+   PyModule_AddObject(module, "BOTH", object);
 
-   version = Py_BuildValue("s", "0.0.20");
-   PyModule_AddObject(module, "VERSION", version);
+   object = Py_BuildValue("s", "0.0.20");
+   PyModule_AddObject(module, "VERSION", object);
 }

--- a/source/constants.h
+++ b/source/constants.h
@@ -1,19 +1,6 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-PyObject *high;
-PyObject *low;
-PyObject *input;
-PyObject *output;
-PyObject *alt0;
-PyObject *pud_off;
-PyObject *pud_up;
-PyObject *pud_down;
-PyObject *rising_edge;
-PyObject *falling_edge;
-PyObject *both_edge;
-PyObject *version;
-
 void define_constants(PyObject *module);
 
 #endif


### PR DESCRIPTION
Building with GCC 10.2.1 fails due linking errors caused by having multiple
definitions of the variables defined in the source/constants.h header file.

Fix this by moving the variables definition to the source/constants.c file,
to avoid the variables to be defined each time that the header is included.

While being there, use a single variable instead of having one for each
object that is added to the module.