### PR TITLE
Fix compilation for newer versions of Python

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -599,8 +599,10 @@ PyMODINIT_FUNC initGPIO(void)
 
    initlog(LOG_INFO, NULL, BBIO_LOG_OPTION);
 
+#if PY_VERSION_HEX < 0x03090000
    if (!PyEval_ThreadsInitialized())
       PyEval_InitThreads();
+#endif
 
    if (Py_AtExit(event_cleanup) != 0)
    {


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

`PyEval_ThreadsInitialized()` and `PyEval_InitThreads()` are deprecated (see https://docs.python.org/3.9/whatsnew/3.9.html#deprecated) and break the build.

This PR adds a version check to ignore these calls if we are compiling with a newer Python version.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

N/A

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

N/A