### PR TITLE
Explicitly included sys/time.h in py_gpio.c as it broke compilation

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -35,7 +35,7 @@ SOFTWARE.
 #include "c_pinmux.h"
 #include <unistd.h>
 #include <syslog.h>
-#include <sys/time.c>
+#include <sys/time.h>
 static int gpio_warnings = 1;
 
 struct py_callback

--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -35,7 +35,7 @@ SOFTWARE.
 #include "c_pinmux.h"
 #include <unistd.h>
 #include <syslog.h>
-
+#include <sys/time.c>
 static int gpio_warnings = 1;
 
 struct py_callback


### PR DESCRIPTION

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- Scope of the Change - An explicit mention of the library sys/time.h in py_gpio.c. 
- This was needed as on the Debian-13 image for BeagleBone black, I was hit with
- the error - 
- 
- source/py_gpio.c:231:9: error: implicit declaration of function ‘gettimeofday’ 
- [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-fun ction-declaration-Wimplicit-function-declaration8;;] 

