### PR TITLE
Fix PyPI publishing: switch to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   upload-pypi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +60,4 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
PyPI dropped support for username/password authentication for package uploads. The current workflow uses `TWINE_USERNAME` / `TWINE_PASSWORD` secrets with `twine upload`, which now returns a hard `403 Forbidden`.

This PR switches to [OIDC Trusted Publishing](https://docs.pypi.org/trusted-publishers/), the recommended approach:

- Adds `permissions: id-token: write` to the job
- Replaces the `twine upload` step (with secrets) with `pypa/gh-action-pypi-publish@release/v1`
- Removes the now-unnecessary `PYPI_USERNAME` / `PYPI_PASSWORD` secrets

**Required PyPI-side setup (one-time):** A package maintainer needs to add a Trusted Publisher on PyPI for this package:
1. Go to https://pypi.org/manage/project/adafruit-bbio/settings/publishing/
2. Add a new publisher: GitHub → `adafruit/adafruit-beaglebone-io-python` → workflow `release.yml` → environment name (leave blank)

Once configured, no secrets are needed and publishing will work automatically on release.

Closes #2
