### PR TITLE
Fix uboot_overlay_enabled() for newer BBB Debian images

### DIFF
--- a/source/common.c
+++ b/source/common.c
@@ -560,11 +560,23 @@ int get_spi_bus_path_number(unsigned int spi)
    If u-boot overlays are enabled, then device tree overlays should not
    be loaded with the cape manager by writing to the slots file.  There
    is currently a kernel bug that causes the write to hang.
+
+   On newer Debian images, bone_capemgr is no longer present. Instead,
+   the presence of /proc/device-tree/chosen/overlays (a directory) indicates
+   that U-Boot overlays are in use.
 */
 int uboot_overlay_enabled(void) {
     const char *cmd = "/bin/grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline";
     char uboot_overlay;
     FILE *file = NULL;
+    DIR *dir = NULL;
+
+    dir = opendir("/proc/device-tree/chosen/overlays");
+    if (dir != NULL) {
+       closedir(dir);
+       syslog(LOG_DEBUG, "Adafruit_BBIO: uboot_overlay_enabled() is true\n");
+       return 1;
+    }
 
     file = popen(cmd, "r");
     if (file == NULL) {


### PR DESCRIPTION
Supersedes #372 (thanks @cozzyd for the original fix and diagnosis).

On newer Debian images, `bone_capemgr` is no longer present. The existing `uboot_overlay_enabled()` check using `grep bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline` therefore never fires, breaking overlay detection on these images.

This adds a check for the presence of `/proc/device-tree/chosen/overlays` — a directory that indicates U-Boot overlays are in use — before falling through to the legacy `cmdline` check. Uses `opendir()` (via the already-included `<dirent.h>`) rather than `fopen()`, since the path is a directory, not a file.
